### PR TITLE
feat(maxOutputTokens) Updated with max token configuration

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
@@ -8,6 +8,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.ai.tool.internal.JsonObjectSchemaTranslator;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -85,6 +86,12 @@ public class ChatConfiguration {
             It Does not trigger the thinking process itself—only affects whether the output is parsed and returned."""
     )
     private Property<Boolean> returnThinking;
+    @Schema(
+        description = "Maximum number of tokens the model can generate in the completion (response). This limits the length of the output.",
+        example = "1024"
+    )
+    @Nullable
+    private Property<Integer> maxToken;
     public dev.langchain4j.model.chat.request.ResponseFormat computeResponseFormat(RunContext runContext) throws IllegalVariableEvaluationException {
         if (responseFormat == null) {
             return dev.langchain4j.model.chat.request.ResponseFormat.TEXT;

--- a/src/main/java/io/kestra/plugin/ai/provider/AmazonBedrock.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/AmazonBedrock.java
@@ -111,6 +111,7 @@ public class AmazonBedrock extends ModelProvider {
                 .temperature(runContext.render(configuration.getTemperature()).as(Double.class).orElse(null))
                 .responseFormat(configuration.computeResponseFormat(runContext))
                 .enableReasoning(thinkingBudgetTokens)
+                .maxOutputTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
                 .build()
             )
             .logRequests(runContext.render(configuration.getLogRequests()).as(Boolean.class).orElse(false))

--- a/src/main/java/io/kestra/plugin/ai/provider/Anthropic.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/Anthropic.java
@@ -107,6 +107,7 @@ public class Anthropic extends ModelProvider {
             .thinkingType(thinkingEnabled ? ENABLED : null)
             .thinkingBudgetTokens(thinkingBudgetTokens)
             .returnThinking(runContext.render(configuration.getReturnThinking()).as(Boolean.class).orElse(null))
+            .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
             .build();
     }
 

--- a/src/main/java/io/kestra/plugin/ai/provider/AzureOpenAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/AzureOpenAI.java
@@ -116,6 +116,7 @@ public class AzureOpenAI extends ModelProvider {
                 .logRequestsAndResponses(logRequestAndResponses)
                 .responseFormat(configuration.computeResponseFormat(runContext))
                 .listeners(List.of(new TimingChatModelListener()))
+                .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
                 .build();
         } else if (tenantId != null && clientId != null && clientSecret != null) {
             return AzureOpenAiChatModel.builder()
@@ -129,6 +130,7 @@ public class AzureOpenAI extends ModelProvider {
                 .logRequestsAndResponses(logRequestAndResponses)
                 .responseFormat(configuration.computeResponseFormat(runContext))
                 .listeners(List.of(new TimingChatModelListener()))
+                .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
                 .build();
         } else {
             throw new IllegalArgumentException("You need to set an API Key or a tenantId, clientId and clientSecret");

--- a/src/main/java/io/kestra/plugin/ai/provider/DeepSeek.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/DeepSeek.java
@@ -96,6 +96,7 @@ public class DeepSeek extends ModelProvider {
             .responseFormat(configuration.computeResponseFormat(runContext))
             .returnThinking(runContext.render(configuration.getReturnThinking()).as(Boolean.class).orElse(null))
             .listeners(List.of(new TimingChatModelListener()))
+            .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
             .build();
     }
 

--- a/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
@@ -88,6 +88,7 @@ public class GoogleGemini extends ModelProvider {
             .listeners(List.of(new TimingChatModelListener()))
             .thinkingConfig(getThinkingConfig(configuration, runContext))
             .returnThinking(runContext.render(configuration.getReturnThinking()).as(Boolean.class).orElse(null))
+            .maxOutputTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
             .build();
     }
 

--- a/src/main/java/io/kestra/plugin/ai/provider/GoogleVertexAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GoogleVertexAI.java
@@ -100,6 +100,7 @@ public class GoogleVertexAI extends ModelProvider {
             .responseMimeType(responseFormat.type() == ResponseFormatType.JSON ? "application/json" : null)
             .responseSchema(responseFormat.jsonSchema() != null ? SchemaHelper.from(responseFormat.jsonSchema().rootElement()) : null)
             .listeners(List.of(new TimingChatModelListener()))
+            .maxOutputTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
             .build();
     }
 

--- a/src/main/java/io/kestra/plugin/ai/provider/MistralAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/MistralAI.java
@@ -88,6 +88,7 @@ public class MistralAI extends ModelProvider {
             .logger(runContext.logger())
             .responseFormat(configuration.computeResponseFormat(runContext))
             .listeners(List.of(new TimingChatModelListener()))
+            .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
             .build();
     }
 

--- a/src/main/java/io/kestra/plugin/ai/provider/OpenAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/OpenAI.java
@@ -90,6 +90,7 @@ public class OpenAI extends ModelProvider {
             .logger(runContext.logger())
             .responseFormat(configuration.computeResponseFormat(runContext))
             .listeners(List.of(new TimingChatModelListener()))
+            .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
             .build();
     }
 

--- a/src/main/java/io/kestra/plugin/ai/provider/OpenRouter.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/OpenRouter.java
@@ -88,6 +88,7 @@ public class OpenRouter extends ModelProvider {
             .logger(runContext.logger())
             .responseFormat(configuration.computeResponseFormat(runContext))
             .listeners(List.of(new TimingChatModelListener()))
+            .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
             .build();
     }
 


### PR DESCRIPTION
closes https://github.com/kestra-io/plugin-ai/issues/158. Updated maxOutput token support for the following models:

- AmazonBedrock
- Anthropic
- AzureOpenAI
- DeepSeek
- GoogleGemini
- GoogleVertexAI
- MistralAI
- OpenAI
- OpenRouter

Note: Ollama does not provide a direct max_tokens parameter like other API's Instead, it uses a context window (.num-ctx) that limits the total tokens for both input and output, so the code was not updated for Ollama.
