### PR TITLE
feat(retriever): introduce SqlDatabaseRetriever

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,10 @@ dependencies {
     implementation "dev.langchain4j:langchain4j-web-search-engine-tavily"
     implementation "dev.langchain4j:langchain4j-mcp"
 
+    // retrievers
+    implementation "dev.langchain4j:langchain4j-experimental-sql"
+    compileOnly "com.zaxxer:HikariCP"
+
     implementation "com.azure:azure-identity" // For Azure OpenAI
 
     implementation 'org.awaitility:awaitility:4.3.0'

--- a/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
@@ -24,14 +24,12 @@ import io.kestra.plugin.ai.domain.*;
 import io.kestra.plugin.ai.provider.TimingChatModelListener;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
@@ -234,6 +232,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
     aliases = "io.kestra.plugin.langchain4j.rag.ChatCompletion"
 )
 public class ChatCompletion extends Task implements RunnableTask<ChatCompletion.Output> {
+
     @Schema(title = "System message", description = "Instruction that sets the assistant's role, tone, and constraints for this task.")
     protected Property<String> systemMessage;
 

--- a/src/main/java/io/kestra/plugin/ai/retriever/SqlDatabaseRetriever.java
+++ b/src/main/java/io/kestra/plugin/ai/retriever/SqlDatabaseRetriever.java
@@ -1,0 +1,149 @@
+package io.kestra.plugin.ai.retriever;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.langchain4j.experimental.rag.content.retriever.sql.SqlDatabaseContentRetriever;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.ai.domain.ChatConfiguration;
+import io.kestra.plugin.ai.domain.ContentRetrieverProvider;
+import io.kestra.plugin.ai.domain.ModelProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import javax.sql.DataSource;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonDeserialize
+@Schema(
+    title = "SQL Database content retriever using LangChain4j experimental SqlDatabaseContentRetriever. " +
+        "⚠ IMPORTANT: the database user should have READ-ONLY permissions."
+)
+@Plugin(
+    examples = {
+        @Example(
+            full = true,
+            title = "RAG chat with a SQL Database content retriever (answers grounded in database data)",
+            code = """
+                id: rag
+                namespace: company.ai
+
+                tasks:
+                  - id: chat_with_rag_and_sql_retriever
+                    type: io.kestra.plugin.ai.rag.ChatCompletion
+                    chatProvider:
+                      type: io.kestra.plugin.ai.provider.GoogleGemini
+                      modelName: gemini-2.0-flash
+                      apiKey: "{{ kv('GOOGLE_API_KEY') }}"
+                    contentRetrievers:
+                      - type: io.kestra.plugin.ai.retriever.SqlDatabaseRetriever
+                        databaseType: POSTGRESQL
+                        jdbcUrl: "jdbc:postgresql://localhost:5432/mydb"
+                        username: "{{ kv('DB_USER') }}"
+                        password: "{{ kv('DB_PASSWORD') }}"
+                    prompt: "What are the top 5 customers by revenue?"
+                """
+        )
+    }
+)
+public class SqlDatabaseRetriever extends ContentRetrieverProvider {
+
+    @Schema(
+        title = "Supported database types.",
+        description = "Determines the default JDBC driver and connection format."
+    )
+    public enum DatabaseType {
+        POSTGRESQL,
+        MYSQL,
+        H2
+    }
+
+    @Schema(title = "Type of database to connect to (PostgreSQL, MySQL, or H2).")
+    @NotNull
+    private Property<DatabaseType> databaseType;
+
+    @Schema(title = "JDBC connection URL to the target database.")
+    private Property<String> jdbcUrl;
+
+    @Schema(title = "Database username.")
+    @NotNull
+    private Property<String> username;
+
+    @Schema(title = "Database password.")
+    @NotNull
+    private Property<String> password;
+
+    @Schema(title = "Optional JDBC driver class name. Automatically resolved if not provided.")
+    private Property<String> driver;
+
+    @Schema(title = "Maximum number of database connections in the pool.")
+    @Builder.Default
+    private Property<Integer> maxPoolSize = Property.ofValue(2);
+
+    @Schema(title = "Language model provider.")
+    @NotNull
+    @PluginProperty
+    private ModelProvider provider;
+
+    @Schema(title = "Language model configuration.")
+    @NotNull
+    @PluginProperty
+    @Builder.Default
+    private ChatConfiguration configuration = ChatConfiguration.empty();
+
+    @Override
+    public ContentRetriever contentRetriever(RunContext runContext) throws IllegalVariableEvaluationException {
+        DatabaseType rDatabaseType = runContext.render(this.databaseType).as(DatabaseType.class).orElseThrow();
+        String rJdbcUrl = runContext.render(this.jdbcUrl).as(String.class).orElse(null);
+        String rUsername = runContext.render(this.username).as(String.class).orElseThrow();
+        String rPassword = runContext.render(this.password).as(String.class).orElseThrow();
+        String rDriver = runContext.render(this.driver).as(String.class).orElse(null);
+        int rMaxPoolSize = runContext.render(this.maxPoolSize).as(Integer.class).orElse(2);
+
+        // Determine default driver if not provided
+        if (rDriver == null) {
+            rDriver = switch (rDatabaseType) {
+                case POSTGRESQL -> "org.postgresql.Driver";
+                case MYSQL -> "com.mysql.cj.jdbc.Driver";
+                case H2 -> "org.h2.Driver";
+            };
+        }
+
+        try {
+            Class.forName(rDriver);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("JDBC driver not found on classpath: " + rDriver, e);
+        }
+
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(rJdbcUrl);
+        config.setUsername(rUsername);
+        config.setPassword(rPassword);
+        config.setDriverClassName(rDriver);
+        config.setMaximumPoolSize(rMaxPoolSize);
+        config.setPoolName("SqlDatabaseRetrieverPool");
+
+        DataSource dataSource = new HikariDataSource(config);
+        ChatModel chatModel = provider.chatModel(runContext, configuration);
+
+        return SqlDatabaseContentRetriever.builder()
+            .dataSource(dataSource)
+            .chatModel(chatModel)
+            .build();
+    }
+}


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/4697

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
