### PR TITLE
feat(provider): introduce GitHubModels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     implementation "dev.langchain4j:langchain4j-anthropic"
     implementation "dev.langchain4j:langchain4j-azure-open-ai"
     implementation "dev.langchain4j:langchain4j-bedrock"
+    implementation "dev.langchain4j:langchain4j-github-models"
     implementation "dev.langchain4j:langchain4j-google-ai-gemini"
     implementation "dev.langchain4j:langchain4j-mistral-ai"
     implementation "dev.langchain4j:langchain4j-ollama"

--- a/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
@@ -62,6 +62,7 @@ public class ChatConfiguration {
             When using a JSON schema, the output will be returned under the key `jsonOutput`."""
     )
     private ResponseFormat responseFormat;
+
     @Schema(
         title = "Enable Thinking",
         description = """
@@ -78,6 +79,7 @@ public class ChatConfiguration {
             thoughts or chain-of-thought sequences, allowing the model to perform multi-step reasoning before producing the final output."""
     )
     private Property<Integer> thinkingBudgetTokens;
+
     @Schema(
         title = "Return Thinking",
         description = """
@@ -86,12 +88,14 @@ public class ChatConfiguration {
             It Does not trigger the thinking process itself—only affects whether the output is parsed and returned."""
     )
     private Property<Boolean> returnThinking;
+
     @Schema(
         description = "Maximum number of tokens the model can generate in the completion (response). This limits the length of the output.",
         example = "1024"
     )
     @Nullable
     private Property<Integer> maxToken;
+
     public dev.langchain4j.model.chat.request.ResponseFormat computeResponseFormat(RunContext runContext) throws IllegalVariableEvaluationException {
         if (responseFormat == null) {
             return dev.langchain4j.model.chat.request.ResponseFormat.TEXT;

--- a/src/main/java/io/kestra/plugin/ai/provider/GitHubModels.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GitHubModels.java
@@ -1,0 +1,143 @@
+package io.kestra.plugin.ai.provider;
+
+import com.azure.ai.inference.models.ChatCompletionsResponseFormat;
+import com.azure.ai.inference.models.ChatCompletionsResponseFormatJsonObject;
+import com.azure.ai.inference.models.ChatCompletionsResponseFormatText;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.github.GitHubModelsChatModel;
+import dev.langchain4j.model.github.GitHubModelsEmbeddingModel;
+import dev.langchain4j.model.image.ImageModel;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.ai.domain.ChatConfiguration;
+import io.kestra.plugin.ai.domain.ModelProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonDeserialize
+@Schema(
+    title = "GitHub Models AI Model Provider",
+    description = "Uses GitHub Models via Azure AI Inference API."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Chat completion with GitHub Models",
+            full = true,
+            code = {
+                """
+                    id: chat_completion
+                    namespace: company.ai
+
+                    inputs:
+                      - id: prompt
+                        type: STRING
+
+                    tasks:
+                      - id: chat_completion
+                        type: io.kestra.plugin.ai.completion.ChatCompletion
+                        provider:
+                          type: io.kestra.plugin.ai.provider.GitHubModels
+                          gitHubToken: "{{ kv('GITHUB_TOKEN') }}"
+                          modelName: gpt-4o-mini
+                        messages:
+                          - type: SYSTEM
+                            content: You are a helpful assistant, answer concisely.
+                          - type: USER
+                            content: "{{inputs.prompt}}"
+                    """
+            }
+        )
+    }
+)
+public class GitHubModels extends ModelProvider {
+
+    @Schema(
+        title = "GitHub Token",
+        description = "Personal Access Token (PAT) used to access GitHub Models."
+    )
+    @NotNull
+    private Property<String> gitHubToken;
+
+    @Override
+    public ChatModel chatModel(RunContext runContext, ChatConfiguration configuration)
+        throws IllegalVariableEvaluationException {
+
+        var logRequests = runContext.render(configuration.getLogRequests()).as(Boolean.class).orElse(false);
+        var logResponses = runContext.render(configuration.getLogResponses()).as(Boolean.class).orElse(false);
+        var seed = runContext.render(configuration.getSeed()).as(Integer.class).orElse(null);
+
+        var builder = GitHubModelsChatModel.builder()
+            .gitHubToken(runContext.render(this.gitHubToken).as(String.class).orElseThrow())
+            .modelName(runContext.render(this.getModelName()).as(String.class).orElseThrow())
+            .temperature(runContext.render(configuration.getTemperature()).as(Double.class).orElse(null))
+            .topP(runContext.render(configuration.getTopP()).as(Double.class).orElse(null))
+            .seed(seed != null ? seed.longValue() : null)
+            .responseFormat(toAzureResponseFormat(runContext, configuration))
+            .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
+            .logRequestsAndResponses(logRequests || logResponses)
+            .listeners(List.of(new TimingChatModelListener()));
+
+        runContext.render(this.baseUrl).as(String.class).ifPresent(builder::endpoint);
+
+        return builder.build();
+    }
+
+    @Override
+    public ImageModel imageModel(RunContext runContext) {
+        throw new UnsupportedOperationException("GitHub Models is not supported for image generation.");
+    }
+
+    @Override
+    public EmbeddingModel embeddingModel(RunContext runContext)
+        throws IllegalVariableEvaluationException {
+
+        var logRequests = runContext.render(Property.ofValue(false)).as(Boolean.class).orElse(false);
+        var logResponses = runContext.render(Property.ofValue(false)).as(Boolean.class).orElse(false);
+
+        var builder = GitHubModelsEmbeddingModel.builder()
+            .gitHubToken(runContext.render(this.gitHubToken).as(String.class).orElseThrow())
+            .modelName(runContext.render(this.getModelName()).as(String.class).orElseThrow())
+            .logRequestsAndResponses(logRequests || logResponses);
+
+        runContext.render(this.baseUrl).as(String.class).ifPresent(builder::endpoint);
+
+        return builder.build();
+    }
+
+    private ChatCompletionsResponseFormat toAzureResponseFormat(
+        RunContext runContext,
+        ChatConfiguration configuration
+    ) throws IllegalVariableEvaluationException {
+
+        var lc4jFormat = configuration.computeResponseFormat(runContext);
+
+        if (lc4jFormat.jsonSchema() != null) {
+            runContext.logger().warn(
+                "GitHub Models responseFormat supports JSON mode but does not enforce JSON Schema. " +
+                    "Use prompt constraints and validate downstream."
+            );
+        }
+
+        if (lc4jFormat.type() == dev.langchain4j.model.chat.request.ResponseFormatType.JSON) {
+            return new ChatCompletionsResponseFormatJsonObject();
+        }
+
+        return new ChatCompletionsResponseFormatText();
+    }
+}


### PR DESCRIPTION
closes https://github.com/kestra-io/plugin-ai/issues/171

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Every time you use `runContext.metric(...)` you have to add a `@Metric` ([see this doc](https://kestra.io/docs/plugin-developer-guide/document#document-the-plugin-metrics))
- [ ] Docs don't support to have both tasks/triggers in the root package (e.g. `io.kestra.plugin.kubernetes`) and in a sub package (e.g. `io.kestra.plugin.kubernetes.kubectl`), whether it's: all tasks/triggers in the root package OR only tasks/triggers in sub packages.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (to be set executable with `chmod +x setup-unit.sh`) (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`). If needed, create an executable (`chmod +x cleanup-unit.sh`) `cleanup-unit.sh` to remove the potential costly resources (tables, datasets, etc).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
