### PR TITLE
docs: add a warning on function calling + response format

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
@@ -31,7 +31,11 @@ import java.util.List;
 @JsonDeserialize
 @Schema(
     title = "Google Gemini Model Provider",
-    description = "WARNING: when using tools, this provider didn't support JSON Schema with `anyOf`."
+    description = """
+        WARNING:
+        - when using tools, this provider didn't support JSON Schema with `anyOf`
+        - function calling (tools) and response format are not yet supported together
+        """
 )
 @Plugin(
     examples = {
@@ -40,29 +44,29 @@ import java.util.List;
             full = true,
             code = {
                 """
-                id: chat_completion
-                namespace: company.ai
+                    id: chat_completion
+                    namespace: company.ai
 
-                inputs:
-                  - id: prompt
-                    type: STRING
+                    inputs:
+                      - id: prompt
+                        type: STRING
 
-                tasks:
-                  - id: chat_completion
-                    type: io.kestra.plugin.ai.completion.ChatCompletion
-                    provider:
-                      type: io.kestra.plugin.ai.provider.GoogleGemini
-                      apiKey: "{{ kv('GOOGLE_API_KEY') }}"
-                      modelName: gemini-2.5-flash
-                      thinkingEnabled: true
-                      thinkingBudgetTokens: 1024
-                      returnThinking: true
-                    messages:
-                      - type: SYSTEM
-                        content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
-                      - type: USER
-                        content: "{{inputs.prompt}}"
-                """
+                    tasks:
+                      - id: chat_completion
+                        type: io.kestra.plugin.ai.completion.ChatCompletion
+                        provider:
+                          type: io.kestra.plugin.ai.provider.GoogleGemini
+                          apiKey: "{{ kv('GOOGLE_API_KEY') }}"
+                          modelName: gemini-2.5-flash
+                          thinkingEnabled: true
+                          thinkingBudgetTokens: 1024
+                          returnThinking: true
+                        messages:
+                          - type: SYSTEM
+                            content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
+                          - type: USER
+                            content: "{{inputs.prompt}}"
+                    """
             }
         ),
         @Example(
@@ -70,38 +74,39 @@ import java.util.List;
             full = true,
             code = {
                 """
-                id: chat_completion
-                namespace: company.ai
+                    id: chat_completion
+                    namespace: company.ai
 
-                inputs:
-                  - id: prompt
-                    type: STRING
+                    inputs:
+                      - id: prompt
+                        type: STRING
 
-                tasks:
-                  - id: chat_completion
-                    type: io.kestra.plugin.ai.completion.ChatCompletion
-                    provider:
-                      type: io.kestra.plugin.ai.provider.GoogleGemini
-                      apiKey: "{{ kv('GOOGLE_API_KEY') }}"
-                      modelName: gemini-2.5-flash
-                      clientPem: "{{ kv('CLIENT_PEM') }}"
-                      caPem: "{{ kv('CA_PEM') }}"
-                      baseUrl: "https://internal.gemini.company.com/endpoint"
-                      thinkingEnabled: true
-                      thinkingBudgetTokens: 1024
-                      returnThinking: true
-                    messages:
-                      - type: SYSTEM
-                        content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
-                      - type: USER
-                        content: "{{inputs.prompt}}"
-                """
+                    tasks:
+                      - id: chat_completion
+                        type: io.kestra.plugin.ai.completion.ChatCompletion
+                        provider:
+                          type: io.kestra.plugin.ai.provider.GoogleGemini
+                          apiKey: "{{ kv('GOOGLE_API_KEY') }}"
+                          modelName: gemini-2.5-flash
+                          clientPem: "{{ kv('CLIENT_PEM') }}"
+                          caPem: "{{ kv('CA_PEM') }}"
+                          baseUrl: "https://internal.gemini.company.com/endpoint"
+                          thinkingEnabled: true
+                          thinkingBudgetTokens: 1024
+                          returnThinking: true
+                        messages:
+                          - type: SYSTEM
+                            content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
+                          - type: USER
+                            content: "{{inputs.prompt}}"
+                    """
             }
         )
     },
     aliases = "io.kestra.plugin.langchain4j.provider.GoogleGemini"
 )
 public class GoogleGemini extends ModelProvider {
+
     @Schema(title = "API Key")
     @NotNull
     private Property<String> apiKey;

--- a/src/main/java/io/kestra/plugin/ai/tool/internal/JsonObjectSchemaTranslator.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/internal/JsonObjectSchemaTranslator.java
@@ -46,7 +46,7 @@ public final class JsonObjectSchemaTranslator {
     }
 
     @SuppressWarnings("unchecked")
-    private static Map<String, JsonSchemaElement>  mapProperties(Map<String, Object> properties) {
+    private static Map<String, JsonSchemaElement> mapProperties(Map<String, Object> properties) {
         return MapUtils.emptyOnNull(properties).entrySet().stream()
             .filter(prop -> !prop.getKey().equals("type"))
             .map(entry -> {
@@ -67,8 +67,8 @@ public final class JsonObjectSchemaTranslator {
     @SuppressWarnings("unchecked")
     private static JsonSchemaElement mapSchema(Map<String, Object> schema) {
         var type = (String) schema.get("type");
-        var title =  (String) schema.get("title");
-        var _enum =  (List<String>) schema.get("enum");
+        var title = (String) schema.get("title");
+        var _enum = (List<String>) schema.get("enum");
         var anyOf = (List<Map<String, Object>>) schema.get("anyOf");
         var ref = (String) schema.get("$ref");
         if (_enum != null) {
@@ -95,7 +95,8 @@ public final class JsonObjectSchemaTranslator {
             case "boolean" -> JsonBooleanSchema.builder().description(title).build();
             case "null" -> new JsonNullSchema();
             case "object" -> JsonObjectSchema.builder().description(title).build();
-            case "array" -> JsonArraySchema.builder().description(title).items(mapSchema((Map<String, Object>) schema.get("items"))).build();
+            case "array" ->
+                JsonArraySchema.builder().description(title).items(mapSchema((Map<String, Object>) schema.get("items"))).build();
             // it should not happen, but in this case we use String as it's the most proficient type for an LLM
             case null -> new JsonStringSchema();
             // we coalesce other types to String for now...
@@ -106,9 +107,10 @@ public final class JsonObjectSchemaTranslator {
     private static Map<String, JsonSchemaElement> replaceDefinitions(Map<String, JsonSchemaElement> properties, Map<String, JsonSchemaElement> definitions) {
         return properties.entrySet().stream()
             .map(entry -> {
-                JsonSchemaElement schema = switch(entry.getValue()) {
-                    case JsonReferenceSchema jsonReferenceSchema -> definitions.getOrDefault(jsonReferenceSchema.reference(),
-                        JsonObjectSchema.builder().description(jsonReferenceSchema.description()).build());
+                JsonSchemaElement schema = switch (entry.getValue()) {
+                    case JsonReferenceSchema jsonReferenceSchema ->
+                        definitions.getOrDefault(jsonReferenceSchema.reference(),
+                            JsonObjectSchema.builder().description(jsonReferenceSchema.description()).build());
                     case JsonObjectSchema jsonObjectSchema -> JsonObjectSchema.builder()
                         .description(jsonObjectSchema.description())
                         .required(jsonObjectSchema.required()).


### PR DESCRIPTION
closes https://github.com/kestra-io/plugin-ai/issues/217

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Every time you use `runContext.metric(...)` you have to add a `@Metric` ([see this doc](https://kestra.io/docs/plugin-developer-guide/document#document-the-plugin-metrics))
- [ ] Docs don't support to have both tasks/triggers in the root package (e.g. `io.kestra.plugin.kubernetes`) and in a sub package (e.g. `io.kestra.plugin.kubernetes.kubectl`), whether it's: all tasks/triggers in the root package OR only tasks/triggers in sub packages.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.
- [ ] Update the existing `index.yaml` for the main plugin, and for each new subpackage add a metadata file named exactly after the subpackage (e.g. `s3.yaml` for `io.kestra.plugin.aws.s3`) under `src/main/resources/metadata/`, following the same schema.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (to be set executable with `chmod +x setup-unit.sh`) (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`). If needed, create an executable (`chmod +x cleanup-unit.sh`) `cleanup-unit.sh` to remove the potential costly resources (tables, datasets, etc).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).