### PR TITLE
docs(subgroups): improve subgroup descriptions

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/agent/package-info.java
+++ b/src/main/java/io/kestra/plugin/ai/agent/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    description = "This sub-group of plugins contains AI tasks.",
+    description = "Tasks that run AI agents combining system prompts, user input, tools, content retrievers, and optional memory to produce grounded responses.",
     categories = { PluginSubGroup.PluginCategory.AI, PluginSubGroup.PluginCategory.DATABASE }
 )
 package io.kestra.plugin.ai.agent;

--- a/src/main/java/io/kestra/plugin/ai/completion/package-info.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    description = "This sub-group of plugins contains AI completion tasks.",
+    description = "Tasks that call LLMs for chat, classification, image generation, and JSON-structured extraction, with optional tools, memory, and provider flexibility.",
     categories = { PluginSubGroup.PluginCategory.AI }
 )
 package io.kestra.plugin.ai.completion;

--- a/src/main/java/io/kestra/plugin/ai/embeddings/package-info.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    description = "This sub-group of plugins contains Embeddings Store providers for the other Langchain4j plugins.",
+    description = "Tasks that provision embeddings stores (Chroma, PGVector, Pinecone, Redis, Qdrant, etc.) for chunk storage and similarity search powering RAG flows.",
     categories = { PluginSubGroup.PluginCategory.AI, PluginSubGroup.PluginCategory.DATABASE }
 )
 package io.kestra.plugin.ai.embeddings;

--- a/src/main/java/io/kestra/plugin/ai/memory/package-info.java
+++ b/src/main/java/io/kestra/plugin/ai/memory/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    description = "This sub-group of plugins contains Memory providers for the other Langchain4j plugins.",
+    description = "Tasks that supply conversational memory backends (Kestra KV Store, Redis, PostgreSQL) to persist recent messages for agents and chat completions.",
     categories = { PluginSubGroup.PluginCategory.AI }
 )
 package io.kestra.plugin.ai.memory;

--- a/src/main/java/io/kestra/plugin/ai/package-info.java
+++ b/src/main/java/io/kestra/plugin/ai/package-info.java
@@ -1,6 +1,5 @@
 @PluginSubGroup(
-    description = "This sub-group of plugins contains tasks for Generative AI for Kestra.\n" +
-        "It uses the Langchain4j framework.",
+    description = "Tasks that orchestrate generative AI in Kestra with LangChain4j, covering chat completions, agents, RAG, tools, and shared providers.",
     categories = PluginSubGroup.PluginCategory.AI
 )
 package io.kestra.plugin.ai;

--- a/src/main/java/io/kestra/plugin/ai/provider/package-info.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    description = "This sub-group of plugins contains Large Language Model (LLM) providers for the other Langchain4j plugins.",
+    description = "Tasks that configure Large Language Model providers (OpenAI, Gemini, Anthropic, Mistral, Bedrock, etc.) to supply chat/completion models used across the AI plugins.",
     categories = PluginSubGroup.PluginCategory.AI
 )
 package io.kestra.plugin.ai.provider;

--- a/src/main/java/io/kestra/plugin/ai/rag/package-info.java
+++ b/src/main/java/io/kestra/plugin/ai/rag/package-info.java
@@ -1,7 +1,6 @@
 @PluginSubGroup(
     title = "RAG",
-    description = "This sub-group of plugins contains tasks for Retrieval Augmented Generation AI for Kestra.\n" +
-        "It uses the Langchain4j framework.",
+    description = "Tasks that ingest, chunk, and embed documents, search vectors, and run retrieval-augmented chat so LLM answers stay grounded in indexed content.",
     categories = PluginSubGroup.PluginCategory.AI
 )
 package io.kestra.plugin.ai.rag;

--- a/src/main/java/io/kestra/plugin/ai/retriever/package-info.java
+++ b/src/main/java/io/kestra/plugin/ai/retriever/package-info.java
@@ -1,6 +1,5 @@
 @PluginSubGroup(
-    description = "This sub-group of plugins contains content retriever for Retrieval Augmented Generation AI for Kestra.\n" +
-        "It uses the Langchain4j framework.",
+    description = "Tasks that pull external context for Retrieval Augmented Generation: web search via Google or Tavily, or SQL database retrieval feeding results into AI prompts.",
     categories = PluginSubGroup.PluginCategory.AI
 )
 package io.kestra.plugin.ai.retriever;

--- a/src/main/java/io/kestra/plugin/ai/tool/package-info.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/package-info.java
@@ -1,6 +1,5 @@
 @PluginSubGroup(
-    description = "This sub-group of plugins contains tools for Generative AI for Kestra.\n" +
-        "It uses the Langchain4j framework.",
+    description = "Tasks that expose tools agents can call: Kestra flow/task runners, code execution, MCP clients, and web search to extend LLM reasoning with actions and real-time data.",
     categories = PluginSubGroup.PluginCategory.AI
 )
 package io.kestra.plugin.ai.tool;

--- a/src/main/resources/metadata/agent.yaml
+++ b/src/main/resources/metadata/agent.yaml
@@ -1,7 +1,7 @@
 group: io.kestra.plugin.ai.agent
 name: "agent"
 title: "Agent"
-description: "This sub-group of plugins contains AI tasks."
+description: "Tasks that run AI agents combining system prompts, user input, tools, content retrievers, and optional memory to produce grounded responses."
 body: ""
 videos: []
 createdBy: "Kestra Core Team"

--- a/src/main/resources/metadata/completion.yaml
+++ b/src/main/resources/metadata/completion.yaml
@@ -1,7 +1,7 @@
 group: io.kestra.plugin.ai.completion
 name: "completion"
 title: "Completion"
-description: "This sub-group of plugins contains AI completion tasks."
+description: "Tasks that call LLMs for chat, classification, image generation, and JSON-structured extraction, with optional tools, memory, and provider flexibility."
 body: ""
 videos: []
 createdBy: "Kestra Core Team"

--- a/src/main/resources/metadata/embeddings.yaml
+++ b/src/main/resources/metadata/embeddings.yaml
@@ -1,7 +1,7 @@
 group: io.kestra.plugin.ai.embeddings
 name: "embeddings"
 title: "Embeddings"
-description: "This sub-group of plugins contains Embeddings Store providers for the other Langchain4j plugins."
+description: "Tasks that provision embeddings stores (Chroma, PGVector, Pinecone, Redis, Qdrant, etc.) for chunk storage and similarity search powering RAG flows."
 body: ""
 videos: []
 createdBy: "Kestra Core Team"

--- a/src/main/resources/metadata/index.yaml
+++ b/src/main/resources/metadata/index.yaml
@@ -1,7 +1,7 @@
 group: io.kestra.plugin.ai
 name: "ai"
 title: "AI"
-description: "This sub-group of plugins contains tasks for Generative AI for Kestra. It uses the Langchain4j framework."
+description: "Tasks that orchestrate generative AI in Kestra with LangChain4j, covering chat completions, agents, RAG, tools, and shared providers."
 body: ""
 videos: []
 createdBy: "Kestra Core Team"

--- a/src/main/resources/metadata/memory.yaml
+++ b/src/main/resources/metadata/memory.yaml
@@ -1,7 +1,7 @@
 group: io.kestra.plugin.ai.memory
 name: "memory"
 title: "Memory"
-description: "This sub-group of plugins contains Memory providers for the other Langchain4j plugins."
+description: "Tasks that supply conversational memory backends (Kestra KV Store, Redis, PostgreSQL) to persist recent messages for agents and chat completions."
 body: ""
 videos: []
 createdBy: "Kestra Core Team"

--- a/src/main/resources/metadata/provider.yaml
+++ b/src/main/resources/metadata/provider.yaml
@@ -1,7 +1,7 @@
 group: io.kestra.plugin.ai.provider
 name: "provider"
 title: "Provider"
-description: "This sub-group of plugins contains Large Language Model (LLM) providers for the other Langchain4j plugins."
+description: "Tasks that configure Large Language Model providers (OpenAI, Gemini, Anthropic, Mistral, Bedrock, etc.) to supply chat/completion models used across the AI plugins."
 body: ""
 videos: []
 createdBy: "Kestra Core Team"

--- a/src/main/resources/metadata/rag.yaml
+++ b/src/main/resources/metadata/rag.yaml
@@ -1,7 +1,7 @@
 group: io.kestra.plugin.ai.rag
 name: "rag"
 title: "RAG"
-description: "This sub-group of plugins contains tasks for Retrieval Augmented Generation AI for Kestra. It uses the Langchain4j framework."
+description: "Tasks that ingest, chunk, and embed documents, search vectors, and run retrieval-augmented chat so LLM answers stay grounded in indexed content."
 body: ""
 videos: []
 createdBy: "Kestra Core Team"

--- a/src/main/resources/metadata/retriever.yaml
+++ b/src/main/resources/metadata/retriever.yaml
@@ -1,7 +1,7 @@
 group: io.kestra.plugin.ai.retriever
 name: "retriever"
 title: "Retriever"
-description: "This sub-group of plugins contains content retriever for Retrieval Augmented Generation AI for Kestra. It uses the Langchain4j framework."
+description: "Tasks that pull external context for Retrieval Augmented Generation: web search via Google or Tavily, or SQL database retrieval feeding results into AI prompts."
 body: ""
 videos: []
 createdBy: "Kestra Core Team"

--- a/src/main/resources/metadata/tool.yaml
+++ b/src/main/resources/metadata/tool.yaml
@@ -1,7 +1,7 @@
 group: io.kestra.plugin.ai.tool
 name: "tool"
 title: "Tool"
-description: "This sub-group of plugins contains tools for Generative AI for Kestra. It uses the Langchain4j framework."
+description: "Tasks that expose tools agents can call: Kestra flow/task runners, code execution, MCP clients, and web search to extend LLM reasoning with actions and real-time data."
 body: ""
 videos: []
 createdBy: "Kestra Core Team"


### PR DESCRIPTION
### What changes are being made and why?
Currently, sub-group descriptions are repetitive and lack full contextualization. Trying to improve these to be more direct and include more information about the group of tasks.