### PR TITLE
Allow for Array Properties within a Json Object Schema  & Strict Json Mode

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/agent/AIAgent.java
+++ b/src/main/java/io/kestra/plugin/ai/agent/AIAgent.java
@@ -31,6 +31,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -670,13 +671,14 @@ public class AIAgent extends Task implements RunnableTask<AIOutput>, OutputFiles
 
         Map<String, Object> additionalVariables = outputFiles != null ? Map.of(ScriptService.VAR_WORKING_DIR, runContext.workingDir().path(true).toString()) : Collections.emptyMap();
         String rPrompt = runContext.render(prompt).as(String.class, additionalVariables).orElseThrow();
+        Duration taskTimeout = runContext.render(this.getTimeout()).as(Duration.class).orElse(Duration.ofSeconds(120));
         List<ToolProvider> toolProviders = ListUtils.emptyOnNull(tools);
 
         var logger = runContext.logger();
 
         try {
             AiServices<Agent> agent = AiServices.builder(Agent.class)
-                .chatModel(provider.chatModel(runContext, configuration))
+                .chatModel(provider.chatModel(runContext, configuration, taskTimeout))
                 .tools(AIUtils.buildTools(runContext, additionalVariables, toolProviders))
                 .maxSequentialToolsInvocations(runContext.render(maxSequentialToolsInvocations).as(Integer.class).orElse(Integer.MAX_VALUE))
                 .systemMessageProvider(throwFunction(memoryId -> runContext.render(systemMessage).as(String.class).orElse(null)))

--- a/src/main/java/io/kestra/plugin/ai/completion/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/ChatCompletion.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 
 import java.util.Collections;
 import java.util.List;
+import java.time.Duration;
 
 import static io.kestra.plugin.ai.domain.ChatMessageType.*;
 
@@ -204,8 +205,10 @@ public class ChatCompletion extends Task implements RunnableTask<ChatCompletion.
             throw new IllegalArgumentException("The last message must be a user message");
         }
 
+        Duration taskTimeout = runContext.render(this.getTimeout()).as(Duration.class).orElse(Duration.ofSeconds(120));
+
         // Get the appropriate model from the factory
-        ChatModel model = this.provider.chatModel(runContext, configuration);
+        ChatModel model = this.provider.chatModel(runContext, configuration, taskTimeout);
 
         List<ToolProvider> toolProviders = ListUtils.emptyOnNull(tools);
         try {

--- a/src/main/java/io/kestra/plugin/ai/completion/Classification.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/Classification.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.time.Duration;
 
 @SuperBuilder
 @ToString
@@ -128,7 +129,8 @@ public class Classification extends Task implements RunnableTask<Classification.
         chatMessages.add(SystemMessage.systemMessage(rSystemMessage));
         chatMessages.add(UserMessage.userMessage(rPrompt));
 
-        ChatModel model = this.provider.chatModel(runContext, configuration);
+        Duration taskTimeout = runContext.render(this.getTimeout()).as(Duration.class).orElse(Duration.ofSeconds(120));
+        ChatModel model = this.provider.chatModel(runContext, configuration, taskTimeout);
         ChatResponse response = model.chat(chatMessages);
 
         logger.debug("Generated Classification: {}", response.aiMessage().text());

--- a/src/main/java/io/kestra/plugin/ai/completion/JSONStructuredExtraction.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/JSONStructuredExtraction.java
@@ -31,6 +31,7 @@ import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.time.Duration;
 
 @SuperBuilder
 @ToString
@@ -190,7 +191,8 @@ public class JSONStructuredExtraction extends Task implements RunnableTask<JSONS
             ))
             .build();
 
-        ChatModel model = this.provider.chatModel(runContext, configuration);
+        Duration taskTimeout = runContext.render(this.getTimeout()).as(Duration.class).orElse(Duration.ofSeconds(120));
+        ChatModel model = this.provider.chatModel(runContext, configuration, taskTimeout);
 
         ChatResponse answer = model.chat(chatRequest);
         logger.debug("Generated Structured Extraction: {}", answer.aiMessage().text());

--- a/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
@@ -180,7 +180,7 @@ public class ChatConfiguration {
                 throw new IllegalArgumentException("`jsonSchema` property is only allowed when `type` is `JSON`");
             }
             if (responseFormatType == ResponseFormatType.TEXT && runContext.render(strictJson).as(Boolean.class).orElse(false)) {
-                throw new IllegalArgumentException("`strictJsonMode` property is only allowed when `type` is `JSON`");
+                throw new IllegalArgumentException("`strictJson` property is only allowed when `type` is `JSON`");
             }
 
             JsonSchema langchain4jJsonSchema = null;

--- a/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
@@ -104,6 +104,14 @@ public class ChatConfiguration {
         return responseFormat.to(runContext);
     }
 
+    public boolean computeStrictJsonMode(RunContext runContext) throws IllegalVariableEvaluationException {
+        if (responseFormat == null) {
+            return false;
+        }
+
+        return responseFormat.strictJsonMode(runContext);
+    }
+
     public static ChatConfiguration empty() {
         return ChatConfiguration.builder().build();
     }
@@ -159,10 +167,20 @@ public class ChatConfiguration {
         )
         private Property<String> jsonSchemaDescription;
 
+        @Schema(
+            title = "Enable strict JSON schema mode",
+            description = "When true, providers that support it enforce strict JSON schema output when `type` is `JSON`."
+        )
+        @Builder.Default
+        private Property<Boolean> strictJsonMode = Property.ofValue(false);
+
         dev.langchain4j.model.chat.request.ResponseFormat to(RunContext runContext) throws IllegalVariableEvaluationException {
             var responseFormatType = runContext.render(type).as(ResponseFormatType.class).orElse(ResponseFormatType.TEXT);
             if (responseFormatType == ResponseFormatType.TEXT && jsonSchema != null) {
                 throw new IllegalArgumentException("`jsonSchema` property is only allowed when `type` is `JSON`");
+            }
+            if (responseFormatType == ResponseFormatType.TEXT && runContext.render(strictJsonMode).as(Boolean.class).orElse(false)) {
+                throw new IllegalArgumentException("`strictJsonMode` property is only allowed when `type` is `JSON`");
             }
 
             JsonSchema langchain4jJsonSchema = null;
@@ -174,6 +192,10 @@ public class ChatConfiguration {
                 .type(runContext.render(type).as(ResponseFormatType.class).orElse(ResponseFormatType.TEXT))
                 .jsonSchema(langchain4jJsonSchema)
                 .build();
+        }
+
+        boolean strictJsonMode(RunContext runContext) throws IllegalVariableEvaluationException {
+            return runContext.render(strictJsonMode).as(Boolean.class).orElse(false);
         }
     }
 }

--- a/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
@@ -172,14 +172,14 @@ public class ChatConfiguration {
             description = "When true, providers that support it enforce strict JSON schema output when `type` is `JSON`."
         )
         @Builder.Default
-        private Property<Boolean> strictJsonMode = Property.ofValue(false);
+        private Property<Boolean> strictJson = Property.ofValue(false);
 
         dev.langchain4j.model.chat.request.ResponseFormat to(RunContext runContext) throws IllegalVariableEvaluationException {
             var responseFormatType = runContext.render(type).as(ResponseFormatType.class).orElse(ResponseFormatType.TEXT);
             if (responseFormatType == ResponseFormatType.TEXT && jsonSchema != null) {
                 throw new IllegalArgumentException("`jsonSchema` property is only allowed when `type` is `JSON`");
             }
-            if (responseFormatType == ResponseFormatType.TEXT && runContext.render(strictJsonMode).as(Boolean.class).orElse(false)) {
+            if (responseFormatType == ResponseFormatType.TEXT && runContext.render(strictJson).as(Boolean.class).orElse(false)) {
                 throw new IllegalArgumentException("`strictJsonMode` property is only allowed when `type` is `JSON`");
             }
 
@@ -195,7 +195,7 @@ public class ChatConfiguration {
         }
 
         boolean strictJsonMode(RunContext runContext) throws IllegalVariableEvaluationException {
-            return runContext.render(strictJsonMode).as(Boolean.class).orElse(false);
+            return runContext.render(strictJson).as(Boolean.class).orElse(false);
         }
     }
 }

--- a/src/main/java/io/kestra/plugin/ai/domain/ModelProvider.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/ModelProvider.java
@@ -14,6 +14,7 @@ import io.kestra.core.plugins.serdes.PluginDeserializer;
 import io.kestra.core.runners.RunContext;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -67,6 +68,13 @@ public abstract class ModelProvider extends AdditionalPlugin {
         description = "CA certificate as text, used to verify SSL/TLS connections when using custom endpoints."
     )
     private Property<String> caPem;
+
+    @Schema(
+        title = "Enable strict JSON schema mode",
+        description = "When true, providers that support it enforce strict JSON schema output when `responseFormat.type` is `JSON`."
+    )
+    @Builder.Default
+    private Property<Boolean> enableStrictJson = Property.ofValue(false);
 
     public abstract ChatModel chatModel(RunContext runContext, ChatConfiguration configuration) throws IllegalVariableEvaluationException;
 

--- a/src/main/java/io/kestra/plugin/ai/domain/ModelProvider.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/ModelProvider.java
@@ -14,7 +14,6 @@ import io.kestra.core.plugins.serdes.PluginDeserializer;
 import io.kestra.core.runners.RunContext;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -68,13 +67,6 @@ public abstract class ModelProvider extends AdditionalPlugin {
         description = "CA certificate as text, used to verify SSL/TLS connections when using custom endpoints."
     )
     private Property<String> caPem;
-
-    @Schema(
-        title = "Enable strict JSON schema mode",
-        description = "When true, providers that support it enforce strict JSON schema output when `responseFormat.type` is `JSON`."
-    )
-    @Builder.Default
-    private Property<Boolean> enableStrictJson = Property.ofValue(false);
 
     public abstract ChatModel chatModel(RunContext runContext, ChatConfiguration configuration) throws IllegalVariableEvaluationException;
 

--- a/src/main/java/io/kestra/plugin/ai/domain/ModelProvider.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/ModelProvider.java
@@ -36,6 +36,7 @@ import java.security.*;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.time.Duration;
 
 @Plugin
 @SuperBuilder(toBuilder = true)
@@ -45,7 +46,6 @@ import java.security.cert.CertificateFactory;
 // AND concrete subclasses must be annotated by @JsonDeserialize() to avoid StackOverflow.
 @JsonDeserialize(using = PluginDeserializer.class)
 public abstract class ModelProvider extends AdditionalPlugin {
-
     @Schema(title = "Model name")
     @NotNull
     private Property<String> modelName;
@@ -69,6 +69,10 @@ public abstract class ModelProvider extends AdditionalPlugin {
     private Property<String> caPem;
 
     public abstract ChatModel chatModel(RunContext runContext, ChatConfiguration configuration) throws IllegalVariableEvaluationException;
+
+    public ChatModel chatModel(RunContext runContext, ChatConfiguration configuration, Duration timeout) throws IllegalVariableEvaluationException {
+        return chatModel(runContext, configuration);
+    }
 
     public abstract ImageModel imageModel(RunContext runContext) throws IllegalVariableEvaluationException;
 

--- a/src/main/java/io/kestra/plugin/ai/provider/MistralAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/MistralAI.java
@@ -96,7 +96,7 @@ public class MistralAI extends ModelProvider {
             .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null));
 
         if (responseFormat.type() == ResponseFormatType.JSON
-            && runContext.render(getEnableStrictJson()).as(Boolean.class).orElse(false)) {
+            && configuration.computeStrictJsonMode(runContext)) {
             chatModelBuilder.supportedCapabilities(RESPONSE_FORMAT_JSON_SCHEMA);
         }
 

--- a/src/main/java/io/kestra/plugin/ai/provider/MistralAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/MistralAI.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.time.Duration;
 import java.util.List;
 
 import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
@@ -76,6 +77,11 @@ public class MistralAI extends ModelProvider {
 
     @Override
     public ChatModel chatModel(RunContext runContext, ChatConfiguration configuration) throws IllegalVariableEvaluationException {
+        return chatModel(runContext, configuration, Duration.ofSeconds(120));
+    }
+
+    @Override
+    public ChatModel chatModel(RunContext runContext, ChatConfiguration configuration, Duration timeout) throws IllegalVariableEvaluationException {
         if (configuration.getTopK() != null) {
             throw new IllegalArgumentException("Mistral models do not support setting the topK parameter.");
         }
@@ -93,6 +99,7 @@ public class MistralAI extends ModelProvider {
             .logger(runContext.logger())
             .responseFormat(responseFormat)
             .listeners(List.of(new TimingChatModelListener()))
+            .timeout(timeout)
             .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null));
 
         if (responseFormat.type() == ResponseFormatType.JSON

--- a/src/main/java/io/kestra/plugin/ai/provider/OpenAICompliantProvider.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/OpenAICompliantProvider.java
@@ -59,7 +59,7 @@ public abstract class OpenAICompliantProvider extends ModelProvider {
             .maxCompletionTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null));
 
         if (responseFormat.type() == ResponseFormatType.JSON
-            && runContext.render(getEnableStrictJson()).as(Boolean.class).orElse(false)) {
+            && configuration.computeStrictJsonMode(runContext)) {
             chatModelBuilder
                 .supportedCapabilities(RESPONSE_FORMAT_JSON_SCHEMA)
                 .strictJsonSchema(true);

--- a/src/main/java/io/kestra/plugin/ai/provider/OpenAICompliantProvider.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/OpenAICompliantProvider.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.time.Duration;
 import java.util.List;
 
 import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
@@ -38,6 +39,11 @@ public abstract class OpenAICompliantProvider extends ModelProvider {
 
     @Override
     public ChatModel chatModel(RunContext runContext, ChatConfiguration configuration) throws IllegalVariableEvaluationException {
+        return chatModel(runContext, configuration, Duration.ofSeconds(120));
+    }
+
+    @Override
+    public ChatModel chatModel(RunContext runContext, ChatConfiguration configuration, Duration timeout) throws IllegalVariableEvaluationException {
         if (configuration.getTopK() != null) {
             throw new IllegalArgumentException("OpenAI models do not support setting the topK parameter.");
         }
@@ -56,6 +62,7 @@ public abstract class OpenAICompliantProvider extends ModelProvider {
             .responseFormat(responseFormat)
             .returnThinking(runContext.render(configuration.getReturnThinking()).as(Boolean.class).orElse(null))
             .listeners(List.of(new TimingChatModelListener()))
+            .timeout(timeout)
             .maxCompletionTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null));
 
         if (responseFormat.type() == ResponseFormatType.JSON

--- a/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
@@ -32,6 +32,7 @@ import lombok.experimental.SuperBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.time.Duration;
 import java.util.stream.Collectors;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
@@ -315,10 +316,11 @@ public class ChatCompletion extends Task implements RunnableTask<ChatCompletion.
     @Override
     public Output run(RunContext runContext) throws Exception {
         List<ToolProvider> toolProviders = ListUtils.emptyOnNull(tools);
+        Duration taskTimeout = runContext.render(this.getTimeout()).as(Duration.class).orElse(Duration.ofSeconds(120));
 
         try {
             AiServices<Assistant> assistant = AiServices.builder(Assistant.class)
-                .chatModel(chatProvider.chatModel(runContext, chatConfiguration))
+                .chatModel(chatProvider.chatModel(runContext, chatConfiguration, taskTimeout))
                 .retrievalAugmentor(buildRetrievalAugmentor(runContext))
                 .tools(AIUtils.buildTools(runContext, Collections.emptyMap(), toolProviders))
                 .systemMessageProvider(throwFunction(memoryId -> runContext.render(systemMessage).as(String.class).orElse(null)))

--- a/src/main/resources/metadata/completion.yaml
+++ b/src/main/resources/metadata/completion.yaml
@@ -2,7 +2,9 @@ group: io.kestra.plugin.ai.completion
 name: "completion"
 title: "Completion"
 description: "Tasks that call LLMs for chat, classification, image generation, and JSON-structured extraction, with optional tools, memory, and provider flexibility."
-body: ""
+body: |
+  For OpenAI-compatible and Mistral chat providers, model requests inherit the task-level `timeout`.
+  If no task timeout is configured, the chat model timeout defaults to `PT120S` (120 seconds).
 videos: []
 createdBy: "Kestra Core Team"
 managedBy: "Kestra Core Team"

--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionStrictJsonModeIntegrationTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionStrictJsonModeIntegrationTest.java
@@ -1,0 +1,94 @@
+package io.kestra.plugin.ai.completion;
+
+import dev.langchain4j.model.chat.request.ResponseFormatType;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.plugin.ai.domain.ChatConfiguration;
+import io.kestra.plugin.ai.domain.ChatMessage;
+import io.kestra.plugin.ai.domain.ChatMessageType;
+import io.kestra.plugin.ai.provider.OpenAI;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.empty;
+
+@KestraTest
+class ChatCompletionStrictJsonModeIntegrationTest {
+    private final String OPENAI_API_KEY = System.getenv("OPENAI_API_KEY");
+    private final String OPENAI_MODEL = System.getenv().getOrDefault("OPENAI_MODEL", "gpt-4o-mini");
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".*")
+    void testChatCompletionOpenAI_givenStrictJsonModeAndArraySchema_shouldReturnStructuredPeopleList() throws Exception {
+        RunContext runContext = runContextFactory.of(Map.of(
+            "apiKey", OPENAI_API_KEY,
+            "modelName", OPENAI_MODEL,
+            "messages", List.of(
+                ChatMessage.builder()
+                    .type(ChatMessageType.USER)
+                    .content("Generate exactly 3 fictional people with silly favorite hobbies.")
+                    .build()
+            )
+        ));
+
+        ChatCompletion task = ChatCompletion.builder()
+            .messages(Property.ofExpression("{{ messages }}"))
+            .configuration(ChatConfiguration.builder()
+                .responseFormat(ChatConfiguration.ResponseFormat.builder()
+                    .type(Property.ofValue(ResponseFormatType.JSON))
+                    .jsonSchema(Property.ofValue(Map.of(
+                        "type", "object",
+                        "properties", Map.of(
+                            "people", Map.of(
+                                "type", "array",
+                                "items", Map.of(
+                                    "type", "object",
+                                    "properties", Map.of(
+                                        "name", Map.of("type", "string"),
+                                        "hobby", Map.of("type", "string")
+                                    ),
+                                    "required", List.of("name", "hobby")
+                                )
+                            )
+                        ),
+                        "required", List.of("people")
+                    )))
+                    .build())
+                .build())
+            .provider(OpenAI.builder()
+                .type(OpenAI.class.getName())
+                .apiKey(Property.ofExpression("{{ apiKey }}"))
+                .modelName(Property.ofExpression("{{ modelName }}"))
+                .enableStrictJson(Property.ofValue(true))
+                .build())
+            .build();
+
+        ChatCompletion.Output output = task.run(runContext);
+
+        assertThat(output.getJsonOutput(), notNullValue());
+        assertThat(output.getJsonOutput().get("people"), instanceOf(List.class));
+
+        List<?> people = (List<?>) output.getJsonOutput().get("people");
+        assertThat(people, not(empty()));
+
+        for (Object person : people) {
+            assertThat(person, instanceOf(Map.class));
+            Map<?, ?> personMap = (Map<?, ?>) person;
+            assertThat(personMap.get("name"), instanceOf(String.class));
+            assertThat(personMap.get("hobby"), instanceOf(String.class));
+        }
+    }
+}

--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionStrictJsonModeIntegrationTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionStrictJsonModeIntegrationTest.java
@@ -66,7 +66,7 @@ class ChatCompletionStrictJsonModeIntegrationTest {
                         ),
                         "required", List.of("people")
                     )))
-                    .strictJsonMode(Property.ofValue(true))
+                    .strictJson(Property.ofValue(true))
                     .build())
                 .build())
             .provider(OpenAI.builder()

--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionStrictJsonModeIntegrationTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionStrictJsonModeIntegrationTest.java
@@ -66,13 +66,13 @@ class ChatCompletionStrictJsonModeIntegrationTest {
                         ),
                         "required", List.of("people")
                     )))
+                    .strictJsonMode(Property.ofValue(true))
                     .build())
                 .build())
             .provider(OpenAI.builder()
                 .type(OpenAI.class.getName())
                 .apiKey(Property.ofExpression("{{ apiKey }}"))
                 .modelName(Property.ofExpression("{{ modelName }}"))
-                .enableStrictJson(Property.ofValue(true))
                 .build())
             .build();
 


### PR DESCRIPTION
### What changes are being made and why?
Enable Strict Json Mode for providers that allow it (starting with openai, openaicompliant, and mistral), as well as allow for proper json schema generation of json objects with properties that are array objects. 

Json Schemas such as: 

{"list_people": [{"name": <>}]}

used to not generate a json schema appropriately. 

### How the changes have been QAed?
Unit test (and a conditional integration test) added




### Contributor Checklist ✅

- [ ] I have read and followed the [plugin contribution guidelines](https://kestra.io/docs/plugin-developer-guide/contribution-guidelines)
