### PR TITLE
Add Langfuse observability to AIAgent via OpenTelemetry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,10 @@ dependencies {
     implementation "dev.langchain4j:langchain4j-agentic-a2a"
 
     implementation "com.azure:azure-identity" // For Azure OpenAI
+
+    implementation "io.opentelemetry:opentelemetry-api"
+    implementation "io.opentelemetry:opentelemetry-sdk"
+    implementation "io.opentelemetry:opentelemetry-exporter-otlp"
 }
 
 

--- a/src/main/java/io/kestra/plugin/ai/domain/LangfuseObservability.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/LangfuseObservability.java
@@ -1,0 +1,92 @@
+package io.kestra.plugin.ai.domain;
+
+import io.kestra.core.models.property.Property;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(
+    title = "Langfuse observability",
+    description = "OpenTelemetry export settings for Langfuse. Payload capture is disabled by default for security."
+)
+public class LangfuseObservability {
+    @Schema(title = "Enable observability")
+    @Builder.Default
+    private Property<Boolean> enabled = Property.ofValue(false);
+
+    @Schema(
+        title = "Langfuse OTLP endpoint",
+        description = "Langfuse OTLP endpoint (for example: https://us.cloud.langfuse.com/api/public/otel)."
+    )
+    private Property<String> endpoint;
+
+    @Schema(title = "Langfuse public key")
+    private Property<String> publicKey;
+
+    @Schema(title = "Langfuse secret key")
+    private Property<String> secretKey;
+
+    @Schema(title = "Service name")
+    @Builder.Default
+    private Property<String> serviceName = Property.ofValue("kestra-plugin-ai");
+
+    @Schema(title = "Environment")
+    private Property<String> environment;
+
+    @Schema(title = "Release")
+    private Property<String> release;
+
+    @Schema(
+        title = "Capture prompt",
+        description = "If true, prompt content is sent to Langfuse under input attributes. Disabled by default."
+    )
+    @Builder.Default
+    private Property<Boolean> capturePrompt = Property.ofValue(false);
+
+    @Schema(
+        title = "Capture system message",
+        description = "If true, system message content is sent in metadata. Disabled by default."
+    )
+    @Builder.Default
+    private Property<Boolean> captureSystemMessage = Property.ofValue(false);
+
+    @Schema(
+        title = "Capture output",
+        description = "If true, model output content is sent to Langfuse under output attributes. Disabled by default."
+    )
+    @Builder.Default
+    private Property<Boolean> captureOutput = Property.ofValue(false);
+
+    @Schema(
+        title = "Capture tool arguments",
+        description = "If true, tool arguments are sent in tool execution events. Disabled by default."
+    )
+    @Builder.Default
+    private Property<Boolean> captureToolArguments = Property.ofValue(false);
+
+    @Schema(
+        title = "Capture tool results",
+        description = "If true, tool results are sent in tool execution events. Disabled by default."
+    )
+    @Builder.Default
+    private Property<Boolean> captureToolResults = Property.ofValue(false);
+
+    @Schema(
+        title = "Maximum payload characters",
+        description = "Maximum number of characters sent for any captured payload field. Longer values are truncated."
+    )
+    @Builder.Default
+    private Property<Integer> maxPayloadChars = Property.ofValue(2000);
+
+    @Schema(title = "Export timeout", description = "Timeout used for forceFlush and shutdown operations.")
+    @Builder.Default
+    private Property<Duration> exportTimeout = Property.ofValue(Duration.ofSeconds(5));
+}

--- a/src/main/java/io/kestra/plugin/ai/observability/AgentObservability.java
+++ b/src/main/java/io/kestra/plugin/ai/observability/AgentObservability.java
@@ -1,0 +1,20 @@
+package io.kestra.plugin.ai.observability;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.service.Result;
+import io.kestra.plugin.ai.domain.TokenUsage;
+
+public interface AgentObservability extends AutoCloseable {
+    void onStart(String prompt, String systemMessage);
+
+    void onToolArgumentsError(String toolName, String requestId, Throwable error);
+
+    void onToolExecutionError(String toolName, String requestId, Throwable error);
+
+    void onCompletion(Result<AiMessage> completion, TokenUsage tokenUsage);
+
+    void onFailure(Throwable error);
+
+    @Override
+    void close();
+}

--- a/src/main/java/io/kestra/plugin/ai/observability/NoopAgentObservability.java
+++ b/src/main/java/io/kestra/plugin/ai/observability/NoopAgentObservability.java
@@ -1,0 +1,42 @@
+package io.kestra.plugin.ai.observability;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.service.Result;
+import io.kestra.plugin.ai.domain.TokenUsage;
+
+public final class NoopAgentObservability implements AgentObservability {
+    public static final NoopAgentObservability INSTANCE = new NoopAgentObservability();
+
+    private NoopAgentObservability() {
+    }
+
+    @Override
+    public void onStart(String prompt, String systemMessage) {
+        // no-op
+    }
+
+    @Override
+    public void onToolArgumentsError(String toolName, String requestId, Throwable error) {
+        // no-op
+    }
+
+    @Override
+    public void onToolExecutionError(String toolName, String requestId, Throwable error) {
+        // no-op
+    }
+
+    @Override
+    public void onCompletion(Result<AiMessage> completion, TokenUsage tokenUsage) {
+        // no-op
+    }
+
+    @Override
+    public void onFailure(Throwable error) {
+        // no-op
+    }
+
+    @Override
+    public void close() {
+        // no-op
+    }
+}

--- a/src/main/java/io/kestra/plugin/ai/observability/OpenTelemetryLangfuseObservability.java
+++ b/src/main/java/io/kestra/plugin/ai/observability/OpenTelemetryLangfuseObservability.java
@@ -1,0 +1,544 @@
+package io.kestra.plugin.ai.observability;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.service.Result;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.plugin.ai.domain.ChatConfiguration;
+import io.kestra.plugin.ai.domain.LangfuseObservability;
+import io.kestra.plugin.ai.domain.ModelProvider;
+import io.kestra.plugin.ai.domain.TokenUsage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.resources.ResourceBuilder;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public final class OpenTelemetryLangfuseObservability implements AgentObservability {
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson(false);
+    private static final String TRACE_NAME = "AIAgent";
+    private static final String INSTRUMENTATION_SCOPE = "io.kestra.plugin.ai.agent.AIAgent";
+
+    private final RunContext runContext;
+    private final String taskId;
+    private final String providerType;
+    private final String modelName;
+    private final ChatConfiguration chatConfiguration;
+    private final ResolvedConfig config;
+    private final SdkTracerProvider tracerProvider;
+    private final OpenTelemetrySdk openTelemetrySdk;
+    private final Tracer tracer;
+
+    private Span span;
+
+    private OpenTelemetryLangfuseObservability(
+        RunContext runContext,
+        String taskId,
+        String providerType,
+        String modelName,
+        ChatConfiguration chatConfiguration,
+        ResolvedConfig config,
+        SpanExporter spanExporter
+    ) {
+        this.runContext = runContext;
+        this.taskId = taskId;
+        this.providerType = providerType;
+        this.modelName = modelName;
+        this.chatConfiguration = chatConfiguration;
+        this.config = config;
+
+        ResourceBuilder resourceBuilder = Resource.builder()
+            .put("service.name", config.serviceName());
+
+        if (config.environment() != null) {
+            resourceBuilder.put("deployment.environment", config.environment());
+        }
+        if (config.release() != null) {
+            resourceBuilder.put("service.version", config.release());
+        }
+
+        this.tracerProvider = SdkTracerProvider.builder()
+            .setResource(Resource.getDefault().merge(resourceBuilder.build()))
+            .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
+            .build();
+
+        this.openTelemetrySdk = OpenTelemetrySdk.builder()
+            .setTracerProvider(this.tracerProvider)
+            .build();
+
+        this.tracer = this.openTelemetrySdk.getTracer(INSTRUMENTATION_SCOPE);
+    }
+
+    public static AgentObservability create(
+        RunContext runContext,
+        LangfuseObservability langfuse,
+        String taskId,
+        ModelProvider provider,
+        ChatConfiguration chatConfiguration
+    ) {
+        try {
+            ResolvedConfig resolvedConfig = ResolvedConfig.from(runContext, langfuse);
+            if (!resolvedConfig.enabled()) {
+                return NoopAgentObservability.INSTANCE;
+            }
+
+            String providerType = provider != null ? provider.getClass().getSimpleName() : null;
+            String modelName = null;
+            if (provider != null && provider.getModelName() != null) {
+                modelName = runContext.render(provider.getModelName()).as(String.class).orElse(null);
+            }
+
+            SpanExporter exporter = OtlpHttpSpanExporter.builder()
+                .setEndpoint(resolvedConfig.endpoint())
+                .addHeader("Authorization", basicAuth(resolvedConfig.publicKey(), resolvedConfig.secretKey()))
+                .setTimeout(resolvedConfig.exportTimeout())
+                .build();
+
+            return new OpenTelemetryLangfuseObservability(
+                runContext,
+                taskId,
+                providerType,
+                modelName,
+                chatConfiguration,
+                resolvedConfig,
+                exporter
+            );
+        } catch (Exception e) {
+            runContext.logger().warn("Failed to initialize Langfuse observability. Falling back to no-op.", e);
+            return NoopAgentObservability.INSTANCE;
+        }
+    }
+
+    @Override
+    public void onStart(String prompt, String systemMessage) {
+        try {
+            span = tracer.spanBuilder("ai.agent.run")
+                .setSpanKind(SpanKind.INTERNAL)
+                .startSpan();
+
+            span.setAttribute("langfuse.trace.name", TRACE_NAME);
+            span.setAttribute("langfuse.observation.type", "generation");
+
+            if (modelName != null) {
+                span.setAttribute("langfuse.observation.model", modelName);
+                span.setAttribute("gen_ai.request.model", modelName);
+            }
+            if (providerType != null) {
+                span.setAttribute("langfuse.observation.model.provider", providerType);
+            }
+
+            List<String> tags = new ArrayList<>();
+            tags.add("kestra");
+            tags.add("ai-agent");
+            if (providerType != null) {
+                tags.add(providerType.toLowerCase());
+            }
+            span.setAttribute(AttributeKey.stringArrayKey("langfuse.trace.tags"), tags);
+
+            Map<String, Object> traceMetadata = traceMetadata(systemMessage);
+            if (!traceMetadata.isEmpty()) {
+                span.setAttribute("langfuse.trace.metadata", toJson(traceMetadata));
+            }
+
+            String correlationId = correlationId();
+            if (correlationId != null) {
+                span.setAttribute("langfuse.session.id", correlationId);
+            }
+
+            Map<String, Object> modelParameters = modelParameters();
+            if (!modelParameters.isEmpty()) {
+                span.setAttribute("langfuse.observation.model.parameters", toJson(modelParameters));
+            }
+
+            if (config.capturePrompt()) {
+                String sanitizedPrompt = sanitize(prompt);
+                span.setAttribute("langfuse.trace.input", sanitizedPrompt);
+                span.setAttribute("langfuse.observation.input", sanitizedPrompt);
+            }
+        } catch (Exception e) {
+            runContext.logger().warn("Failed to start Langfuse span", e);
+        }
+    }
+
+    @Override
+    public void onToolArgumentsError(String toolName, String requestId, Throwable error) {
+        if (span == null) {
+            return;
+        }
+
+        AttributesBuilder attributesBuilder = Attributes.builder();
+        putString(attributesBuilder, "tool.name", toolName);
+        putString(attributesBuilder, "tool.request.id", requestId);
+        putString(attributesBuilder, "error.type", error != null ? error.getClass().getSimpleName() : null);
+        putString(attributesBuilder, "error.message", sanitize(error != null ? error.getMessage() : null));
+
+        span.addEvent("tool.arguments.error", attributesBuilder.build());
+        if (error != null) {
+            span.recordException(error);
+        }
+        span.setStatus(StatusCode.ERROR, "Tool arguments error");
+    }
+
+    @Override
+    public void onToolExecutionError(String toolName, String requestId, Throwable error) {
+        if (span == null) {
+            return;
+        }
+
+        AttributesBuilder attributesBuilder = Attributes.builder();
+        putString(attributesBuilder, "tool.name", toolName);
+        putString(attributesBuilder, "tool.request.id", requestId);
+        putString(attributesBuilder, "error.type", error != null ? error.getClass().getSimpleName() : null);
+        putString(attributesBuilder, "error.message", sanitize(error != null ? error.getMessage() : null));
+
+        span.addEvent("tool.execution.error", attributesBuilder.build());
+        if (error != null) {
+            span.recordException(error);
+        }
+        span.setStatus(StatusCode.ERROR, "Tool execution error");
+    }
+
+    @Override
+    public void onCompletion(Result<AiMessage> completion, TokenUsage tokenUsage) {
+        if (span == null) {
+            return;
+        }
+
+        try {
+            if (tokenUsage != null) {
+                Map<String, Object> usageDetails = new LinkedHashMap<>();
+                putIfNotNull(usageDetails, "input", tokenUsage.getInputTokenCount());
+                putIfNotNull(usageDetails, "output", tokenUsage.getOutputTokenCount());
+                putIfNotNull(usageDetails, "total", tokenUsage.getTotalTokenCount());
+                if (!usageDetails.isEmpty()) {
+                    span.setAttribute("langfuse.observation.usage_details", toJson(usageDetails));
+                }
+            }
+
+            if (completion != null && completion.finishReason() != null) {
+                span.setAttribute("langfuse.observation.level", "DEFAULT");
+                span.setAttribute("ai.finish.reason", completion.finishReason().name());
+            }
+
+            if (config.captureOutput() && completion != null && completion.content() != null) {
+                String output = sanitize(completion.content().text());
+                if (output != null) {
+                    span.setAttribute("langfuse.trace.output", output);
+                    span.setAttribute("langfuse.observation.output", output);
+                }
+            }
+
+            if (completion != null && completion.toolExecutions() != null) {
+                completion.toolExecutions().forEach(toolExecution -> {
+                    AttributesBuilder attrs = Attributes.builder();
+
+                    ToolExecutionRequest request = toolExecution.request();
+                    if (request != null) {
+                        putString(attrs, "tool.name", request.name());
+                        putString(attrs, "tool.request.id", request.id());
+                        if (config.captureToolArguments()) {
+                            putString(attrs, "tool.arguments", sanitize(request.arguments()));
+                        }
+                    }
+
+                    if (config.captureToolResults()) {
+                        putString(attrs, "tool.result", sanitize(toolExecution.result()));
+                    }
+
+                    span.addEvent("tool.execution", attrs.build());
+                });
+            }
+
+            span.setStatus(StatusCode.OK);
+        } catch (Exception e) {
+            runContext.logger().warn("Failed to enrich Langfuse span on completion", e);
+        }
+    }
+
+    @Override
+    public void onFailure(Throwable error) {
+        if (span == null) {
+            return;
+        }
+
+        try {
+            if (error != null) {
+                span.recordException(error);
+                span.setStatus(StatusCode.ERROR, sanitize(error.getMessage()));
+            } else {
+                span.setStatus(StatusCode.ERROR);
+            }
+        } catch (Exception e) {
+            runContext.logger().warn("Failed to mark Langfuse span as failed", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (span != null) {
+            try {
+                span.end();
+            } catch (Exception e) {
+                runContext.logger().warn("Failed to end Langfuse span", e);
+            }
+        }
+
+        waitFor("forceFlush", tracerProvider.forceFlush());
+        waitFor("shutdown", tracerProvider.shutdown());
+
+        try {
+            openTelemetrySdk.close();
+        } catch (Exception e) {
+            runContext.logger().warn("Failed to close OpenTelemetry SDK", e);
+        }
+    }
+
+    private void waitFor(String operation, CompletableResultCode resultCode) {
+        try {
+            resultCode.join(config.exportTimeout().toMillis(), TimeUnit.MILLISECONDS);
+            if (!resultCode.isDone()) {
+                runContext.logger().warn("OpenTelemetry {} timed out after {} ms", operation, config.exportTimeout().toMillis());
+            }
+        } catch (Exception e) {
+            runContext.logger().warn("OpenTelemetry {} failed", operation, e);
+        }
+    }
+
+    private Map<String, Object> traceMetadata(String systemMessage) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+
+        if (taskId != null) {
+            metadata.put("taskId", taskId);
+        }
+
+        if (runContext.flowInfo() != null) {
+            putIfNotNull(metadata, "flowId", runContext.flowInfo().id());
+            putIfNotNull(metadata, "namespace", runContext.flowInfo().namespace());
+        }
+
+        String executionId = nestedLabel("labels", "system", "executionId");
+        putIfNotNull(metadata, "executionId", executionId);
+
+        String taskRunId = nestedLabel("taskrun", "id");
+        putIfNotNull(metadata, "taskRunId", taskRunId);
+
+        if (config.captureSystemMessage() && systemMessage != null) {
+            metadata.put("systemMessage", sanitize(systemMessage));
+        }
+
+        return metadata;
+    }
+
+    private Map<String, Object> modelParameters() {
+        Map<String, Object> parameters = new LinkedHashMap<>();
+
+        try {
+            putIfNotNull(parameters, "temperature", render(chatConfiguration.getTemperature(), Double.class));
+            putIfNotNull(parameters, "topP", render(chatConfiguration.getTopP(), Double.class));
+            putIfNotNull(parameters, "topK", render(chatConfiguration.getTopK(), Integer.class));
+            putIfNotNull(parameters, "seed", render(chatConfiguration.getSeed(), Integer.class));
+            putIfNotNull(parameters, "maxToken", render(chatConfiguration.getMaxToken(), Integer.class));
+            putIfNotNull(parameters, "returnThinking", render(chatConfiguration.getReturnThinking(), Boolean.class));
+        } catch (Exception e) {
+            runContext.logger().debug("Unable to resolve full model parameters for Langfuse metadata", e);
+        }
+
+        return parameters;
+    }
+
+    private String correlationId() {
+        return nestedLabel("labels", "system", "correlationId");
+    }
+
+    private String nestedLabel(String... path) {
+        Object current = runContext.getVariables();
+        for (String key : path) {
+            if (!(current instanceof Map<?, ?> map)) {
+                return null;
+            }
+            current = map.get(key);
+            if (current == null) {
+                return null;
+            }
+        }
+        return String.valueOf(current);
+    }
+
+    private String sanitize(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String sanitized = value.strip();
+        if (sanitized.length() > config.maxPayloadChars()) {
+            return sanitized.substring(0, config.maxPayloadChars()) + "...[truncated]";
+        }
+        return sanitized;
+    }
+
+    private <T> T render(Property<T> property, Class<T> clazz) throws IllegalVariableEvaluationException {
+        return runContext.render(property).as(clazz).orElse(null);
+    }
+
+    private static void putString(AttributesBuilder attributesBuilder, String key, String value) {
+        if (value != null) {
+            attributesBuilder.put(key, value);
+        }
+    }
+
+    private static void putIfNotNull(Map<String, Object> map, String key, Object value) {
+        if (value != null) {
+            map.put(key, value);
+        }
+    }
+
+    private String toJson(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            return MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            return sanitize(String.valueOf(value));
+        }
+    }
+
+    private static String basicAuth(String publicKey, String secretKey) {
+        String credentials = publicKey + ":" + secretKey;
+        String encoded = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + encoded;
+    }
+
+    private record ResolvedConfig(
+        boolean enabled,
+        String endpoint,
+        String publicKey,
+        String secretKey,
+        String serviceName,
+        String environment,
+        String release,
+        boolean capturePrompt,
+        boolean captureSystemMessage,
+        boolean captureOutput,
+        boolean captureToolArguments,
+        boolean captureToolResults,
+        int maxPayloadChars,
+        Duration exportTimeout
+    ) {
+        private static ResolvedConfig from(RunContext runContext, LangfuseObservability raw) throws IllegalVariableEvaluationException {
+            if (raw == null) {
+                return disabled();
+            }
+
+            boolean enabled = render(runContext, raw.getEnabled(), Boolean.class, false);
+            if (!enabled) {
+                return disabled();
+            }
+
+            String endpoint = normalizeEndpoint(render(runContext, raw.getEndpoint(), String.class, null));
+            String publicKey = render(runContext, raw.getPublicKey(), String.class, null);
+            String secretKey = render(runContext, raw.getSecretKey(), String.class, null);
+
+            if (isBlank(endpoint) || isBlank(publicKey) || isBlank(secretKey)) {
+                throw new IllegalArgumentException("Langfuse endpoint, publicKey and secretKey are required when observability is enabled.");
+            }
+
+            int maxPayloadChars = render(runContext, raw.getMaxPayloadChars(), Integer.class, 2000);
+            if (maxPayloadChars <= 0) {
+                maxPayloadChars = 2000;
+            }
+
+            Duration timeout = render(runContext, raw.getExportTimeout(), Duration.class, Duration.ofSeconds(5));
+            if (timeout == null || timeout.isNegative() || timeout.isZero()) {
+                timeout = Duration.ofSeconds(5);
+            }
+
+            return new ResolvedConfig(
+                true,
+                endpoint,
+                publicKey,
+                secretKey,
+                render(runContext, raw.getServiceName(), String.class, "kestra-plugin-ai"),
+                render(runContext, raw.getEnvironment(), String.class, null),
+                render(runContext, raw.getRelease(), String.class, null),
+                render(runContext, raw.getCapturePrompt(), Boolean.class, false),
+                render(runContext, raw.getCaptureSystemMessage(), Boolean.class, false),
+                render(runContext, raw.getCaptureOutput(), Boolean.class, false),
+                render(runContext, raw.getCaptureToolArguments(), Boolean.class, false),
+                render(runContext, raw.getCaptureToolResults(), Boolean.class, false),
+                maxPayloadChars,
+                timeout
+            );
+        }
+
+        private static ResolvedConfig disabled() {
+            return new ResolvedConfig(
+                false,
+                null,
+                null,
+                null,
+                "kestra-plugin-ai",
+                null,
+                null,
+                false,
+                false,
+                false,
+                false,
+                false,
+                2000,
+                Duration.ofSeconds(5)
+            );
+        }
+
+        private static <T> T render(RunContext runContext, Property<T> property, Class<T> clazz, T defaultValue) throws IllegalVariableEvaluationException {
+            if (property == null) {
+                return defaultValue;
+            }
+            return runContext.render(property).as(clazz).orElse(defaultValue);
+        }
+
+        private static String normalizeEndpoint(String endpoint) {
+            if (isBlank(endpoint)) {
+                return endpoint;
+            }
+
+            String normalized = endpoint.strip();
+            if (normalized.endsWith("/")) {
+                normalized = normalized.substring(0, normalized.length() - 1);
+            }
+            if (!normalized.endsWith("/v1/traces") && normalized.contains("/api/public/otel")) {
+                normalized = normalized + "/v1/traces";
+            }
+            return normalized;
+        }
+
+        private static boolean isBlank(String value) {
+            return value == null || value.isBlank();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `observability` support on `AIAgent` with opt-in Langfuse export via OpenTelemetry OTLP
- add runtime abstraction with `AgentObservability`, `NoopAgentObservability`, and `OpenTelemetryLangfuseObservability`
- keep payload capture secure by default (`prompt`, `output`, and tool payload fields are disabled unless explicitly enabled)
- wire tool error and completion metadata/events into emitted spans
- add tests for disabled (no export) and enabled (OTLP export with auth header) modes using WireMock
- add OpenTelemetry dependencies to the build

**Note:** The new dependencies just add an additional 1MB :relieved: 

Reference: https://langfuse.com/integrations/native/opentelemetry

## QA

```yaml
id: ai_agent_observability_gemini3_test
namespace: company.ai

inputs:
  - id: incident
    type: STRING
    defaults: |
      A deep-space relay station on Europa lost telemetry for 17 minutes.
      We need a fast stabilization plan and a clear risk score.

tasks:
  - id: mission_plan
    type: io.kestra.plugin.ai.agent.AIAgent
    systemMessage: |
      You are "Helios", an incident commander AI for orbital infrastructure.
      Be precise, practical, and calm.
      Output must strictly match the JSON schema.
    prompt: |
      Incident report:
      {{ inputs.incident }}

      Build a response with:
      - mission_name: short codename
      - risk_score: 0-100
      - first_actions: exactly 3 short actions
      - rationale: max 80 words
    configuration:
      responseFormat:
        type: JSON
        jsonSchema:
          type: object
          required: ["mission_name", "risk_score", "first_actions", "rationale"]
          properties:
            mission_name:
              type: string
            risk_score:
              type: integer
              minimum: 0
              maximum: 100
            first_actions:
              type: array
              minItems: 3
              maxItems: 3
              items:
                type: string
            rationale:
              type: string

  - id: memory_probe
    type: io.kestra.plugin.ai.agent.AIAgent
    prompt: |
      From your previous answer, restate:
      1) mission_name
      2) first action
      Keep it to one sentence.

  - id: show_outputs
    type: io.kestra.plugin.core.log.Log
    message: |
      mission_plan.jsonOutput = {{ outputs.mission_plan.jsonOutput }}
      memory_probe.textOutput = {{ outputs.memory_probe.textOutput }}

pluginDefaults:
  - type: io.kestra.plugin.ai.agent.AIAgent
    values:
      provider:
        type: io.kestra.plugin.ai.provider.GoogleGemini
        apiKey: "{{ secret('GEMINI_API_KEY') }}"
        modelName: gemini-3.1-pro-preview
      observability:
        enabled: true
        endpoint: "{{ secret('LANGFUSE_OTEL_ENDPOINT') }}"
        publicKey: "{{ secret('LANGFUSE_PUBLIC_KEY') }}"
        secretKey: "{{ secret('LANGFUSE_SECRET_KEY') }}"
        serviceName:  kestra-project-test
        environment: dev
        release: ai-agent-gemini3-test
        capturePrompt: true
        captureSystemMessage: true
        captureOutput: true
        captureToolArguments: true
        captureToolResults: true
      memory:
        type: io.kestra.plugin.ai.memory.KestraKVStore
        memoryId: "{{ execution.id }}"
        ttl: PT1H
        messages: 8
```

The 2 agents finished their work:

<img width="3167" height="1755" alt="image" src="https://github.com/user-attachments/assets/edd9e7a7-5f00-4a71-94c8-8a234004cf5a" />

And in Langfuse I see 2 traces/spans (1 per `AIAgent` task) including metadata (flow/task info), model/provider attributes are set (`GoogleGemini` + the model) and prompt/output are captured:

<img width="3758" height="596" alt="image" src="https://github.com/user-attachments/assets/ad9b3a03-f13c-4a4c-bd46-6456961d04b2" />

<img width="2250" height="2010" alt="image" src="https://github.com/user-attachments/assets/d96a308d-2ec8-4d8e-aa59-c2e27dfce6a7" />

<img width="2250" height="2010" alt="image" src="https://github.com/user-attachments/assets/6cc0dc20-09cf-4871-8cee-05f7d9a086ef" />
