### PR TITLE
fix(provider): pass timeout to all langchain4j chat model builders

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/provider/Anthropic.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/Anthropic.java
@@ -128,7 +128,8 @@ public class Anthropic extends ModelProvider {
             .returnThinking(runContext.render(configuration.getReturnThinking()).as(Boolean.class).orElse(null))
             .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
             .cacheSystemMessages(runContext.render(configuration.getPromptCaching()).as(Boolean.class).orElse(null))
-            .cacheTools(runContext.render(configuration.getPromptCaching()).as(Boolean.class).orElse(null));
+            .cacheTools(runContext.render(configuration.getPromptCaching()).as(Boolean.class).orElse(null))
+            .timeout(timeout);
 
         JdkHttpClientBuilder httpClientBuilder = buildHttpClientWithPemIfAvailable(runContext);
         if (httpClientBuilder != null) {

--- a/src/main/java/io/kestra/plugin/ai/provider/AzureOpenAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/AzureOpenAI.java
@@ -131,7 +131,8 @@ public class AzureOpenAI extends ModelProvider {
             .logRequestsAndResponses(logRequestAndResponses)
             .responseFormat(configuration.computeResponseFormat(runContext))
             .listeners(allListeners)
-            .maxCompletionTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null));
+            .maxCompletionTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
+            .timeout(timeout);
 
         if (apiKey != null) {
             return defaultBuilder

--- a/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
@@ -143,7 +143,8 @@ public class GoogleGemini extends ModelProvider {
             .listeners(allListeners)
             .thinkingConfig(getThinkingConfig(configuration, runContext))
             .returnThinking(runContext.render(configuration.getReturnThinking()).as(Boolean.class).orElse(null))
-            .maxOutputTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null));
+            .maxOutputTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
+            .timeout(timeout);
 
         if (rApiKey != null) {
             chatModelBuilder.apiKey(rApiKey);

--- a/src/main/java/io/kestra/plugin/ai/provider/Ollama.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/Ollama.java
@@ -101,6 +101,7 @@ public class Ollama extends ModelProvider {
             .responseFormat(configuration.computeResponseFormat(runContext))
             .think(runContext.render(configuration.getThinkingEnabled()).as(Boolean.class).orElse(false) ? true : null)
             .returnThinking(runContext.render(configuration.getReturnThinking()).as(Boolean.class).orElse(null))
+            .timeout(timeout)
             .listeners(allListeners);
 
         JdkHttpClientBuilder httpClientBuilder = buildHttpClientWithPemIfAvailable(runContext);

--- a/src/main/java/io/kestra/plugin/ai/provider/OpenRouter.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/OpenRouter.java
@@ -103,7 +103,8 @@ public class OpenRouter extends ModelProvider {
             .logger(runContext.logger())
             .responseFormat(configuration.computeResponseFormat(runContext))
             .listeners(allListeners)
-            .maxCompletionTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null));
+            .maxCompletionTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
+            .timeout(timeout);
 
         JdkHttpClientBuilder httpClientBuilder = buildHttpClientWithPemIfAvailable(runContext);
         if (httpClientBuilder != null) {


### PR DESCRIPTION
## Summary

All providers receive a `timeout` Duration from `ChatCompletion.run()` but several never forwarded it to their langchain4j builder — so the library's internal default (~180s) was always used regardless of the task's `timeout` setting.

**Fixed in this PR** (standard langchain4j builders with `.timeout(Duration)` support):
| Provider | Builder |
|---|---|
| `GoogleGemini` | `GoogleAiGeminiChatModel.builder()` |
| `Anthropic` | `AnthropicChatModel.builder()` |
| `AzureOpenAI` | `AzureOpenAiChatModel.builder()` |
| `Ollama` | `OllamaChatModel.builder()` |
| `OpenRouter` | `OpenAiChatModel.builder()` |

**Not fixed here — need follow-up:**
| Provider | Reason |
|---|---|
| `AmazonBedrock` | Uses AWS SDK `BedrockRuntimeClient`, no `.timeout()` on builder |
| `GoogleVertexAI` | Uses Vertex AI SDK, no `.timeout()` on builder |
| `DashScope` | Community `QwenChatModel`, builder API uncertain |
| `ZhiPuAI` | Community `ZhipuAiChatModel`, builder API uncertain |
| `WatsonxAI` / `WorkersAI` / `LocalAI` / `OciGenAI` | No `chatModel(RunContext, ChatConfiguration, Duration, List)` override — fall back to base class which ignores timeout entirely |

## How to reproduce

Set `timeout: PT10M` on a `ChatCompletion` task using any of the fixed providers — before this fix the task would still time out at ~180s.

## Test plan

- [ ] Confirm `timeout: PT10M` is respected for Gemini (original issue)
- [ ] No regression on providers that were already correct (MistralAI, GitHubModels, OpenAICompliantProvider)