### PR TITLE
feat(telemetry): emit runtime metrics for tools, providers, and embedding stores

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/AIUtils.java
+++ b/src/main/java/io/kestra/plugin/ai/AIUtils.java
@@ -13,7 +13,9 @@ import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.plugin.ai.domain.TokenUsage;
 import io.kestra.plugin.ai.domain.ToolProvider;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.service.tool.ToolExecutionContext;
 import dev.langchain4j.service.tool.ToolExecutor;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
@@ -33,9 +35,18 @@ public final class AIUtils {
         toolProviders.forEach(throwConsumer(provider -> {
             String toolClass = provider.getClass().getName();
             provider.tool(runContext, additionalVariables).forEach((spec, executor) ->
-                tools.put(spec, (toolExecutionRequest, memoryId) -> {
-                    runContext.metric(Counter.of("ai.agent.tool.calls", 1, "tool", toolClass));
-                    return executor.execute(toolExecutionRequest, memoryId);
+                tools.put(spec, new ToolExecutor() {
+                    @Override
+                    public String execute(ToolExecutionRequest request, Object memoryId) {
+                        runContext.metric(Counter.of("ai.agent.tool.calls", 1, "tool", toolClass));
+                        return executor.execute(request, memoryId);
+                    }
+
+                    @Override
+                    public String executeWithContext(ToolExecutionRequest request, ToolExecutionContext context) {
+                        runContext.metric(Counter.of("ai.agent.tool.calls", 1, "tool", toolClass));
+                        return executor.executeWithContext(request, context);
+                    }
                 })
             );
         }));

--- a/src/main/java/io/kestra/plugin/ai/AIUtils.java
+++ b/src/main/java/io/kestra/plugin/ai/AIUtils.java
@@ -30,7 +30,15 @@ public final class AIUtils {
         }
 
         Map<ToolSpecification, ToolExecutor> tools = new HashMap<>();
-        toolProviders.forEach(throwConsumer(provider -> tools.putAll(provider.tool(runContext, additionalVariables))));
+        toolProviders.forEach(throwConsumer(provider -> {
+            String toolClass = provider.getClass().getName();
+            provider.tool(runContext, additionalVariables).forEach((spec, executor) ->
+                tools.put(spec, (toolExecutionRequest, memoryId) -> {
+                    runContext.metric(Counter.of("ai.agent.tool.calls", 1, "tool", toolClass));
+                    return executor.execute(toolExecutionRequest, memoryId);
+                })
+            );
+        }));
         return tools;
     }
 

--- a/src/main/java/io/kestra/plugin/ai/AIUtils.java
+++ b/src/main/java/io/kestra/plugin/ai/AIUtils.java
@@ -15,7 +15,8 @@ import io.kestra.plugin.ai.domain.ToolProvider;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.service.tool.ToolExecutionContext;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
@@ -43,7 +44,7 @@ public final class AIUtils {
                     }
 
                     @Override
-                    public String executeWithContext(ToolExecutionRequest request, ToolExecutionContext context) {
+                    public ToolExecutionResult executeWithContext(ToolExecutionRequest request, InvocationContext context) {
                         runContext.metric(Counter.of("ai.agent.tool.calls", 1, "tool", toolClass));
                         return executor.executeWithContext(request, context);
                     }

--- a/src/main/java/io/kestra/plugin/ai/agent/AIAgent.java
+++ b/src/main/java/io/kestra/plugin/ai/agent/AIAgent.java
@@ -671,6 +671,18 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
             type = Counter.TYPE,
             unit = "token",
             description = "Large Language Model (LLM) total token count"
+        ),
+        @Metric(
+            name = "ai.agent.tool.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of AI tool invocations during agent execution, tagged by tool class name"
+        ),
+        @Metric(
+            name = "ai.provider.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times a chat model is obtained from a provider, tagged by provider class name"
         )
     }
 )
@@ -752,8 +764,10 @@ public class AIAgent extends Task implements RunnableTask<AIOutput>, OutputFiles
         var observabilityListeners = LangfuseObservabilityListeners.create(runContext, observability, this.getId(), provider, configuration);
 
         try {
+            var chatModel = provider.chatModel(runContext, configuration, taskTimeout, observabilityListeners.chatModelListeners());
+            runContext.metric(Counter.of("ai.provider.calls", 1, "provider", provider.getClass().getName()));
             AiServices<Agent> agent = AiServices.builder(Agent.class)
-                .chatModel(provider.chatModel(runContext, configuration, taskTimeout, observabilityListeners.chatModelListeners()))
+                .chatModel(chatModel)
                 .registerListeners(observabilityListeners.aiServiceListeners())
                 .tools(AIUtils.buildTools(runContext, additionalVariables, toolProviders))
                 .maxSequentialToolsInvocations(runContext.render(maxSequentialToolsInvocations).as(Integer.class).orElse(Integer.MAX_VALUE))

--- a/src/main/java/io/kestra/plugin/ai/completion/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/ChatCompletion.java
@@ -229,6 +229,18 @@ import java.util.List;
             type = Counter.TYPE,
             unit = "token",
             description = "Large Language Model (LLM) total token count"
+        ),
+        @Metric(
+            name = "ai.agent.tool.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of AI tool invocations during agent execution, tagged by tool class name"
+        ),
+        @Metric(
+            name = "ai.provider.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times a chat model is obtained from a provider, tagged by provider class name"
         )
     },
     aliases = { "io.kestra.plugin.langchain4j.ChatCompletion", "io.kestra.plugin.langchain4j.completion.ChatCompletion" }
@@ -309,8 +321,10 @@ public class ChatCompletion extends Task implements RunnableTask<ChatCompletion.
             }
 
             // Generate AI response
+            var chatModel = this.provider.chatModel(runContext, configuration, taskTimeout, observabilityListeners.chatModelListeners());
+            runContext.metric(Counter.of("ai.provider.calls", 1, "provider", this.provider.getClass().getName()));
             var builder = AiServices.builder(Assistant.class)
-                .chatModel(this.provider.chatModel(runContext, configuration, taskTimeout, observabilityListeners.chatModelListeners()))
+                .chatModel(chatModel)
                 .registerListeners(observabilityListeners.aiServiceListeners())
                 .systemMessageProvider(
                     chatMemoryId -> chatMessages.stream()

--- a/src/main/java/io/kestra/plugin/ai/completion/Classification.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/Classification.java
@@ -91,6 +91,12 @@ import java.util.Map;
             type = Counter.TYPE,
             unit = "token",
             description = "Large Language Model (LLM) total token count"
+        ),
+        @Metric(
+            name = "ai.provider.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times a chat model is obtained from a provider, tagged by provider class name"
         )
     },
     aliases = { "io.kestra.plugin.langchain4j.Classification", "io.kestra.plugin.langchain4j.completion.Classification" }
@@ -168,6 +174,7 @@ public class Classification extends Task implements RunnableTask<Classification.
 
         Duration taskTimeout = runContext.render(this.getTimeout()).as(Duration.class).orElse(Duration.ofSeconds(120));
         ChatModel model = this.provider.chatModel(runContext, configuration, taskTimeout);
+        runContext.metric(Counter.of("ai.provider.calls", 1, "provider", this.provider.getClass().getName()));
         ChatResponse response = model.chat(chatMessages);
 
         logger.debug("Generated Classification: {}", response.aiMessage().text());

--- a/src/main/java/io/kestra/plugin/ai/completion/JSONStructuredExtraction.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/JSONStructuredExtraction.java
@@ -142,6 +142,12 @@ import java.util.List;
             type = Counter.TYPE,
             unit = "token",
             description = "Large Language Model (LLM) total token count"
+        ),
+        @Metric(
+            name = "ai.provider.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times a chat model is obtained from a provider, tagged by provider class name"
         )
     },
     aliases = { "io.kestra.plugin.langchain4j.JSONStructuredExtraction", "io.kestra.plugin.langchain4j.completion.JSONStructuredExtraction" }
@@ -240,6 +246,7 @@ public class JSONStructuredExtraction extends Task implements RunnableTask<JSONS
 
         Duration taskTimeout = runContext.render(this.getTimeout()).as(Duration.class).orElse(Duration.ofSeconds(120));
         ChatModel model = this.provider.chatModel(runContext, configuration, taskTimeout);
+        runContext.metric(Counter.of("ai.provider.calls", 1, "provider", this.provider.getClass().getName()));
 
         ChatResponse answer = model.chat(chatRequest);
         logger.debug("Generated Structured Extraction: {}", answer.aiMessage().text());

--- a/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
@@ -260,6 +260,24 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
             type = Counter.TYPE,
             unit = "token",
             description = "Large Language Model (LLM) total token count"
+        ),
+        @Metric(
+            name = "ai.agent.tool.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of AI tool invocations during agent execution, tagged by tool class name"
+        ),
+        @Metric(
+            name = "ai.provider.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times a chat or embedding model is obtained from a provider, tagged by provider class name"
+        ),
+        @Metric(
+            name = "ai.embedding.store.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times an embedding store is used, tagged by store class name"
         )
     },
     aliases = "io.kestra.plugin.langchain4j.rag.ChatCompletion"
@@ -341,8 +359,10 @@ public class ChatCompletion extends Task implements RunnableTask<ChatCompletion.
         Duration taskTimeout = runContext.render(this.getTimeout()).as(Duration.class).orElse(Duration.ofSeconds(120));
 
         try {
+            var chatModel = chatProvider.chatModel(runContext, chatConfiguration, taskTimeout);
+            runContext.metric(Counter.of("ai.provider.calls", 1, "provider", chatProvider.getClass().getName()));
             AiServices<Assistant> assistant = AiServices.builder(Assistant.class)
-                .chatModel(chatProvider.chatModel(runContext, chatConfiguration, taskTimeout))
+                .chatModel(chatModel)
                 .retrievalAugmentor(buildRetrievalAugmentor(runContext))
                 .tools(AIUtils.buildTools(runContext, Collections.emptyMap(), toolProviders))
                 .systemMessageProvider(throwFunction(memoryId -> runContext.render(systemMessage).as(String.class).orElse(null)))
@@ -414,10 +434,14 @@ public class ChatCompletion extends Task implements RunnableTask<ChatCompletion.
             throwFunction(
                 embeddings ->
                 {
-                    var embeddingModel = Optional.ofNullable(embeddingProvider).orElse(chatProvider).embeddingModel(runContext);
+                    var actualProvider = Optional.ofNullable(embeddingProvider).orElse(chatProvider);
+                    var embeddingModel = actualProvider.embeddingModel(runContext);
+                    runContext.metric(Counter.of("ai.provider.calls", 1, "provider", actualProvider.getClass().getName()));
+                    var embeddingStore = embeddings.embeddingStore(runContext, embeddingModel.dimension(), false);
+                    runContext.metric(Counter.of("ai.embedding.store.calls", 1, "store", embeddings.getClass().getName()));
                     return EmbeddingStoreContentRetriever.builder()
                         .embeddingModel(embeddingModel)
-                        .embeddingStore(embeddings.embeddingStore(runContext, embeddingModel.dimension(), false))
+                        .embeddingStore(embeddingStore)
                         .maxResults(contentRetrieverConfiguration.getMaxResults())
                         .minScore(contentRetrieverConfiguration.getMinScore())
                         .build();

--- a/src/main/java/io/kestra/plugin/ai/rag/IngestDocument.java
+++ b/src/main/java/io/kestra/plugin/ai/rag/IngestDocument.java
@@ -95,6 +95,18 @@ import lombok.experimental.SuperBuilder;
             type = Counter.TYPE,
             unit = "token",
             description = "Large Language Model (LLM) total token count"
+        ),
+        @Metric(
+            name = "ai.provider.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times an embedding model is obtained from a provider, tagged by provider class name"
+        ),
+        @Metric(
+            name = "ai.embedding.store.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times an embedding store is used, tagged by store class name"
         )
     },
     aliases = "io.kestra.plugin.langchain4j.rag.IngestDocument"
@@ -158,11 +170,13 @@ public class IngestDocument extends Task implements RunnableTask<IngestDocument.
         int rBulkSize = runContext.render(bulkSize).as(Integer.class).orElse(500);
 
         var embeddingModel = provider.embeddingModel(runContext);
+        runContext.metric(Counter.of("ai.provider.calls", 1, "provider", provider.getClass().getName()));
         var embeddingStore = embeddings.embeddingStore(
             runContext,
             embeddingModel.dimension(),
             runContext.render(drop).as(Boolean.class).orElseThrow()
         );
+        runContext.metric(Counter.of("ai.embedding.store.calls", 1, "store", embeddings.getClass().getName()));
 
         var builder = EmbeddingStoreIngestor.builder()
             .embeddingModel(embeddingModel)

--- a/src/main/java/io/kestra/plugin/ai/rag/Search.java
+++ b/src/main/java/io/kestra/plugin/ai/rag/Search.java
@@ -83,6 +83,18 @@ import static io.kestra.core.models.tasks.common.FetchType.NONE;
             unit = "records",
             description = "The number of rows fetch from the embedding store."
         ),
+        @Metric(
+            name = "ai.provider.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times an embedding model is obtained from a provider, tagged by provider class name"
+        ),
+        @Metric(
+            name = "ai.embedding.store.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times an embedding store is used, tagged by store class name"
+        )
     },
     aliases = "io.kestra.plugin.langchain4j.rag.Search"
 )
@@ -126,7 +138,9 @@ public class Search extends Task implements RunnableTask<Search.Output> {
     @Override
     public Output run(RunContext runContext) throws Exception {
         var embeddingModel = provider.embeddingModel(runContext);
+        runContext.metric(Counter.of("ai.provider.calls", 1, "provider", provider.getClass().getName()));
         var store = embeddings.embeddingStore(runContext, embeddingModel.dimension(), false);
+        runContext.metric(Counter.of("ai.embedding.store.calls", 1, "store", embeddings.getClass().getName()));
 
         var renderedQuery = runContext.render(query).as(String.class).orElseThrow();
         var embedding = embeddingModel.embed(renderedQuery).content();

--- a/src/main/java/io/kestra/plugin/ai/retriever/EmbeddingStoreRetriever.java
+++ b/src/main/java/io/kestra/plugin/ai/retriever/EmbeddingStoreRetriever.java
@@ -6,8 +6,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.ai.domain.ContentRetrieverProvider;
@@ -113,6 +115,20 @@ import lombok.experimental.SuperBuilder;
                     prompt: What are the latest trends in data orchestration?
                 """
         )
+    },
+    metrics = {
+        @Metric(
+            name = "ai.provider.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times an embedding model is obtained from a provider, tagged by provider class name"
+        ),
+        @Metric(
+            name = "ai.embedding.store.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times an embedding store is used, tagged by store class name"
+        )
     }
 )
 public class EmbeddingStoreRetriever extends ContentRetrieverProvider {
@@ -151,10 +167,13 @@ public class EmbeddingStoreRetriever extends ContentRetrieverProvider {
     @Override
     public ContentRetriever contentRetriever(RunContext runContext) throws IllegalVariableEvaluationException, IOException {
         var embeddingModel = embeddingProvider.embeddingModel(runContext);
+        runContext.metric(Counter.of("ai.provider.calls", 1, "provider", embeddingProvider.getClass().getName()));
+        var embeddingStore = embeddings.embeddingStore(runContext, embeddingModel.dimension(), false);
+        runContext.metric(Counter.of("ai.embedding.store.calls", 1, "store", embeddings.getClass().getName()));
 
         return EmbeddingStoreContentRetriever.builder()
             .embeddingModel(embeddingModel)
-            .embeddingStore(embeddings.embeddingStore(runContext, embeddingModel.dimension(), false))
+            .embeddingStore(embeddingStore)
             .maxResults(runContext.render(this.maxResults).as(Integer.class).orElse(3))
             .minScore(runContext.render(this.minScore).as(Double.class).orElse(0.0))
             .build();

--- a/src/main/java/io/kestra/plugin/ai/retriever/SqlDatabaseRetriever.java
+++ b/src/main/java/io/kestra/plugin/ai/retriever/SqlDatabaseRetriever.java
@@ -8,8 +8,10 @@ import com.zaxxer.hikari.HikariDataSource;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.ai.domain.ChatConfiguration;
@@ -61,6 +63,14 @@ import lombok.experimental.SuperBuilder;
                         password: "{{ secret('DB_PASSWORD') }}"
                     prompt: "What are the top 5 customers by revenue?"
                 """
+        )
+    },
+    metrics = {
+        @Metric(
+            name = "ai.provider.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times a chat model is obtained from a provider, tagged by provider class name"
         )
     }
 )
@@ -149,6 +159,7 @@ public class SqlDatabaseRetriever extends ContentRetrieverProvider {
 
         DataSource dataSource = new HikariDataSource(config);
         ChatModel chatModel = provider.chatModel(runContext, configuration);
+        runContext.metric(Counter.of("ai.provider.calls", 1, "provider", provider.getClass().getName()));
 
         return SqlDatabaseContentRetriever.builder()
             .dataSource(dataSource)

--- a/src/main/java/io/kestra/plugin/ai/tool/AIAgent.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/AIAgent.java
@@ -6,8 +6,10 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
@@ -75,6 +77,20 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                               apiKey: "{{ secret('GEMINI_API_KEY') }}\""""
             }
         ),
+    },
+    metrics = {
+        @Metric(
+            name = "ai.agent.tool.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of AI tool invocations during nested agent execution, tagged by tool class name"
+        ),
+        @Metric(
+            name = "ai.provider.calls",
+            type = Counter.TYPE,
+            unit = "calls",
+            description = "Number of times a chat model is obtained from a provider, tagged by provider class name"
+        )
     }
 )
 @JsonDeserialize
@@ -140,8 +156,10 @@ public class AIAgent extends ToolProvider {
     public Map<ToolSpecification, ToolExecutor> tool(RunContext runContext, Map<String, Object> additionalVariables) throws Exception {
         toolProviders = ListUtils.emptyOnNull(tools);
 
+        var chatModel = provider.chatModel(runContext, configuration);
+        runContext.metric(Counter.of("ai.provider.calls", 1, "provider", provider.getClass().getName()));
         AiServices<AgentTool> agent = AiServices.builder(AgentTool.class)
-            .chatModel(provider.chatModel(runContext, configuration))
+            .chatModel(chatModel)
             .tools(AIUtils.buildTools(runContext, additionalVariables, toolProviders))
             .maxSequentialToolsInvocations(runContext.render(maxSequentialToolsInvocations).as(Integer.class).orElse(Integer.MAX_VALUE))
             .systemMessageProvider(throwFunction(memoryId -> runContext.render(systemMessage).as(String.class).orElse(null)))


### PR DESCRIPTION
## Summary

Closes #297. Adds three labeled `Counter` metrics emitted at runtime during AI task execution:

- **`ai.agent.tool.calls`** (tag: `tool` = tool class name) — fired on each actual LLM-driven tool invocation, centralized in `AIUtils.buildTools()` via a `ToolExecutor` wrapper
- **`ai.provider.calls`** (tag: `provider` = provider class name) — fired when a `chatModel()` or `embeddingModel()` is obtained, across all tasks that invoke an LLM
- **`ai.embedding.store.calls`** (tag: `store` = store class name) — fired when an embedding store is obtained in RAG tasks and retrievers

All changes are purely additive. No existing APIs are modified.

## Files changed (11)

| File | Metrics added |
|---|---|
| `AIUtils.java` | `ai.agent.tool.calls` (wraps each `ToolExecutor`) |
| `agent/AIAgent.java` | `ai.provider.calls` + `@Metric` |
| `completion/ChatCompletion.java` | `ai.provider.calls` + `@Metric` |
| `completion/Classification.java` | `ai.provider.calls` + `@Metric` |
| `completion/JSONStructuredExtraction.java` | `ai.provider.calls` + `@Metric` |
| `rag/IngestDocument.java` | `ai.provider.calls` + `ai.embedding.store.calls` + `@Metric` |
| `rag/Search.java` | `ai.provider.calls` + `ai.embedding.store.calls` + `@Metric` |
| `rag/ChatCompletion.java` | `ai.provider.calls` ×2 + `ai.embedding.store.calls` + `@Metric` |
| `tool/AIAgent.java` | `ai.provider.calls` + `@Metric` |
| `retriever/SqlDatabaseRetriever.java` | `ai.provider.calls` + `@Metric` |
| `retriever/EmbeddingStoreRetriever.java` | `ai.provider.calls` + `ai.embedding.store.calls` + `@Metric` |

## Test plan

- [ ] CI passes (`./gradlew check`)
- [ ] `ai.agent.tool.calls` is incremented on each tool call (not just registration) — verified by the `ToolExecutor` wrapper in `AIUtils.buildTools()`
- [ ] `ai.provider.calls` is incremented once per `chatModel()`/`embeddingModel()` call per task execution
- [ ] `ai.embedding.store.calls` is incremented once per `embeddingStore()` call in RAG tasks