### PR TITLE
docs(provider): place thinking properties under configuration block

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/provider/Anthropic.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/Anthropic.java
@@ -60,6 +60,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                           type: io.kestra.plugin.ai.provider.Anthropic
                           apiKey: "{{ secret('ANTHROPIC_API_KEY') }}"
                           modelName: claude-3-haiku-20240307
+                        configuration:
                           thinkingEnabled: true
                           thinkingBudgetTokens: 1024
                           returnThinking: false

--- a/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
@@ -70,6 +70,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                           type: io.kestra.plugin.ai.provider.GoogleGemini
                           apiKey: "{{ secret('GOOGLE_API_KEY') }}"
                           modelName: gemini-2.5-flash
+                        configuration:
                           thinkingEnabled: true
                           thinkingBudgetTokens: 1024
                           returnThinking: true
@@ -102,6 +103,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                           clientPem: "{{ secret('CLIENT_PEM') }}"
                           caPem: "{{ secret('CA_PEM') }}"
                           baseUrl: "https://internal.gemini.company.com/endpoint"
+                        configuration:
                           thinkingEnabled: true
                           thinkingBudgetTokens: 1024
                           returnThinking: true

--- a/src/main/java/io/kestra/plugin/ai/provider/Ollama.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/Ollama.java
@@ -60,6 +60,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                           type: io.kestra.plugin.ai.provider.Ollama
                           modelName: llama3
                           endpoint: http://localhost:11434
+                        configuration:
                           thinkingEnabled: true
                           returnThinking: true
                         messages:


### PR DESCRIPTION
## What

Moves `thinkingEnabled`, `thinkingBudgetTokens`, and `returnThinking` from the `provider:` block into the task-level `configuration:` block in the documentation example snippets for `GoogleGemini`, `Ollama`, and `Anthropic`.

## Why

These three properties are defined on `ChatConfiguration` (the task-level `configuration:` block), **not** on the provider classes. The provider runtime reads them from the configuration object (e.g. `configuration.getThinkingEnabled()` in `GoogleGemini.java`).

The `@Example` snippets incorrectly placed them under `provider:`, so users copying the documented example hit a validation error:

```
Validation error: Unrecognized field "thinkingEnabled" (class
io.kestra.plugin.ai.provider.GoogleGemini), not marked as ignorable
```

The generated doc (`io.kestra.plugin.ai.md`) regenerates from these examples at build time.

## Correct structure

```yaml
provider:
  type: io.kestra.plugin.ai.provider.GoogleGemini
  apiKey: "{{ secret('GOOGLE_API_KEY') }}"
  modelName: gemini-2.5-flash
configuration:
  thinkingEnabled: true
  thinkingBudgetTokens: 1024
  returnThinking: true
```

Fixes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)