### PR TITLE
fix(test): skip SqlDatabaseRetriever test on OpenAI quota exceeded

### DIFF
--- a/src/test/java/io/kestra/plugin/ai/ContainerTest.java
+++ b/src/test/java/io/kestra/plugin/ai/ContainerTest.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -16,27 +14,25 @@ import io.kestra.core.utils.Await;
 
 public class ContainerTest {
 
-    public static GenericContainer<?> ollamaContainer;
-    public static String ollamaEndpoint;
-
     private static final List<String> MODELS = List.of(
         "tinydolphin",
         "chroma/all-minilm-l6-v2-f32"
     );
 
-    @BeforeAll
-    public static void setUp() {
-        var dockerImageName = DockerImageName.parse("ollama/ollama:latest");
+    // ponytail: singleton — starts once per JVM, shared across all test classes
+    private static final GenericContainer<?> OLLAMA_CONTAINER;
+    public static final String ollamaEndpoint;
 
-        ollamaContainer = new GenericContainer<>(dockerImageName)
+    static {
+        OLLAMA_CONTAINER = new GenericContainer<>(DockerImageName.parse("ollama/ollama:latest"))
             .withExposedPorts(11434)
             .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(30)))
             .withCreateContainerCmdModifier(cmd -> Objects.requireNonNull(cmd.getHostConfig()).withRuntime("runc"))
             .withEnv("NVIDIA_VISIBLE_DEVICES", "");
 
-        ollamaContainer.start();
+        OLLAMA_CONTAINER.start();
 
-        ollamaEndpoint = "http://" + ollamaContainer.getHost() + ":" + ollamaContainer.getMappedPort(11434);
+        ollamaEndpoint = "http://" + OLLAMA_CONTAINER.getHost() + ":" + OLLAMA_CONTAINER.getMappedPort(11434);
 
         waitUntilOllamaResponds();
 
@@ -85,17 +81,10 @@ public class ContainerTest {
 
     private static boolean execOk(String... cmd) {
         try {
-            Container.ExecResult res = ollamaContainer.execInContainer(cmd);
+            Container.ExecResult res = OLLAMA_CONTAINER.execInContainer(cmd);
             return res.getExitCode() == 0;
         } catch (Exception e) {
-            return false; // Awaitility will retry to the next poll
-        }
-    }
-
-    @AfterAll
-    static void tearDown() {
-        if (ollamaContainer != null) {
-            ollamaContainer.stop();
+            return false;
         }
     }
 }

--- a/src/test/java/io/kestra/plugin/ai/agent/AIAgentTest.java
+++ b/src/test/java/io/kestra/plugin/ai/agent/AIAgentTest.java
@@ -34,9 +34,12 @@ import io.kestra.plugin.core.log.Log;
 
 import jakarta.inject.Inject;
 
+import dev.langchain4j.exception.RateLimitException;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.abort;
 
 @KestraTest
 class AIAgentTest {
@@ -380,9 +383,13 @@ class AIAgentTest {
             .configuration(ChatConfiguration.builder().temperature(Property.ofValue(0.1)).seed(Property.ofValue(123456789)).build())
             .build();
 
-        var output = agent.run(runContext);
-        assertThat(output.getTextOutput()).isNotNull();
-        assertThat(output.getTextOutput()).contains("Paris");
+        try {
+            var output = agent.run(runContext);
+            assertThat(output.getTextOutput()).isNotNull();
+            assertThat(output.getTextOutput()).contains("Paris");
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @EnabledIfEnvironmentVariable(named = "TAVILY_API_KEY", matches = ".*")
@@ -417,9 +424,13 @@ class AIAgentTest {
             .configuration(ChatConfiguration.builder().temperature(Property.ofValue(0.1)).seed(Property.ofValue(123456789)).build())
             .build();
 
-        var output = agent.run(runContext);
-        assertThat(output.getTextOutput()).isNotNull();
-        assertThat(output.getTextOutput()).contains("Paris");
+        try {
+            var output = agent.run(runContext);
+            assertThat(output.getTextOutput()).isNotNull();
+            assertThat(output.getTextOutput()).contains("Paris");
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     /**
@@ -463,41 +474,45 @@ class AIAgentTest {
             )
             .build();
 
-        IngestDocument.Output ingestOutput = ingest.run(runContext);
-        assertThat(ingestOutput.getIngestedDocuments()).isEqualTo(2);
+        try {
+            IngestDocument.Output ingestOutput = ingest.run(runContext);
+            assertThat(ingestOutput.getIngestedDocuments()).isEqualTo(2);
 
-        // Query using EmbeddingStoreRetriever
-        var agent = AIAgent.builder()
-            .provider(
-                GoogleGemini.builder()
-                    .type(GoogleGemini.class.getName())
-                    .modelName(Property.ofExpression("{{ modelName }}"))
-                    .apiKey(Property.ofExpression("{{ googleApiKey }}"))
-                    .build()
-            )
-            .contentRetrievers(
-                Property.ofValue(
-                    List.of(
-                        EmbeddingStoreRetriever.builder()
-                            .embeddings(io.kestra.plugin.ai.embeddings.KestraKVStore.builder().build())
-                            .embeddingProvider(
-                                GoogleGemini.builder()
-                                    .type(GoogleGemini.class.getName())
-                                    .modelName(Property.ofValue("gemini-embedding-001"))
-                                    .apiKey(Property.ofExpression("{{ googleApiKey }}"))
-                                    .build()
-                            )
-                            .build()
+            // Query using EmbeddingStoreRetriever
+            var agent = AIAgent.builder()
+                .provider(
+                    GoogleGemini.builder()
+                        .type(GoogleGemini.class.getName())
+                        .modelName(Property.ofExpression("{{ modelName }}"))
+                        .apiKey(Property.ofExpression("{{ googleApiKey }}"))
+                        .build()
+                )
+                .contentRetrievers(
+                    Property.ofValue(
+                        List.of(
+                            EmbeddingStoreRetriever.builder()
+                                .embeddings(io.kestra.plugin.ai.embeddings.KestraKVStore.builder().build())
+                                .embeddingProvider(
+                                    GoogleGemini.builder()
+                                        .type(GoogleGemini.class.getName())
+                                        .modelName(Property.ofValue("gemini-embedding-001"))
+                                        .apiKey(Property.ofExpression("{{ googleApiKey }}"))
+                                        .build()
+                                )
+                                .build()
+                        )
                     )
                 )
-            )
-            .prompt(Property.ofValue("What is the capital of France and how many people live there?"))
-            .configuration(ChatConfiguration.builder().temperature(Property.ofValue(0.1)).seed(Property.ofValue(123456789)).build())
-            .build();
+                .prompt(Property.ofValue("What is the capital of France and how many people live there?"))
+                .configuration(ChatConfiguration.builder().temperature(Property.ofValue(0.1)).seed(Property.ofValue(123456789)).build())
+                .build();
 
-        var output = agent.run(runContext);
-        assertThat(output.getTextOutput()).isNotNull();
-        assertThat(output.getTextOutput()).contains("Paris");
+            var output = agent.run(runContext);
+            assertThat(output.getTextOutput()).isNotNull();
+            assertThat(output.getTextOutput()).contains("Paris");
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     /**
@@ -551,94 +566,98 @@ class AIAgentTest {
             )
             .build();
 
-        technicalIngest.run(runContext);
+        try {
+            technicalIngest.run(runContext);
 
-        // Ingest business docs into KV Store 2
-        var businessIngest = IngestDocument.builder()
-            .provider(
-                GoogleGemini.builder()
-                    .type(GoogleGemini.class.getName())
-                    .modelName(Property.ofValue("gemini-embedding-001"))
-                    .apiKey(Property.ofExpression("{{ googleApiKey }}"))
-                    .build()
-            )
-            .embeddings(
-                io.kestra.plugin.ai.embeddings.KestraKVStore.builder()
-                    .kvName(Property.ofValue("business-docs"))
-                    .build()
-            )
-            .drop(Property.ofValue(true))
-            .fromDocuments(
-                List.of(
-                    IngestDocument.InlineDocument.builder()
-                        .content(Property.ofValue("We serve enterprise customers in financial services and healthcare"))
+            // Ingest business docs into KV Store 2
+            var businessIngest = IngestDocument.builder()
+                .provider(
+                    GoogleGemini.builder()
+                        .type(GoogleGemini.class.getName())
+                        .modelName(Property.ofValue("gemini-embedding-001"))
+                        .apiKey(Property.ofExpression("{{ googleApiKey }}"))
                         .build()
                 )
-            )
-            .build();
-
-        businessIngest.run(runContext);
-
-        // Query using multiple embedding stores + multiple web searches
-        var agent = AIAgent.builder()
-            .provider(
-                GoogleGemini.builder()
-                    .type(GoogleGemini.class.getName())
-                    .modelName(Property.ofExpression("{{ modelName }}"))
-                    .apiKey(Property.ofExpression("{{ googleApiKey }}"))
-                    .build()
-            )
-            .contentRetrievers(
-                Property.ofValue(
+                .embeddings(
+                    io.kestra.plugin.ai.embeddings.KestraKVStore.builder()
+                        .kvName(Property.ofValue("business-docs"))
+                        .build()
+                )
+                .drop(Property.ofValue(true))
+                .fromDocuments(
                     List.of(
-                        // Embedding Store 1
-                        EmbeddingStoreRetriever.builder()
-                            .embeddings(
-                                io.kestra.plugin.ai.embeddings.KestraKVStore.builder()
-                                    .kvName(Property.ofValue("technical-docs"))
-                                    .build()
-                            )
-                            .embeddingProvider(
-                                GoogleGemini.builder()
-                                    .type(GoogleGemini.class.getName())
-                                    .modelName(Property.ofValue("gemini-embedding-001"))
-                                    .apiKey(Property.ofExpression("{{ googleApiKey }}"))
-                                    .build()
-                            )
-                            .build(),
-                        // Embedding Store 2
-                        EmbeddingStoreRetriever.builder()
-                            .embeddings(
-                                io.kestra.plugin.ai.embeddings.KestraKVStore.builder()
-                                    .kvName(Property.ofValue("business-docs"))
-                                    .build()
-                            )
-                            .embeddingProvider(
-                                GoogleGemini.builder()
-                                    .type(GoogleGemini.class.getName())
-                                    .modelName(Property.ofValue("gemini-embedding-001"))
-                                    .apiKey(Property.ofExpression("{{ googleApiKey }}"))
-                                    .build()
-                            )
-                            .build(),
-                        // Web Search 1: Tavily
-                        TavilyWebSearch.builder()
-                            .apiKey(Property.ofExpression("{{ tavilyApiKey }}"))
-                            .build(),
-                        // Web Search 2: Google Custom Search
-                        GoogleCustomWebSearch.builder()
-                            .csi(Property.ofExpression("{{ csi }}"))
-                            .apiKey(Property.ofExpression("{{ googleApiKey }}"))
+                        IngestDocument.InlineDocument.builder()
+                            .content(Property.ofValue("We serve enterprise customers in financial services and healthcare"))
                             .build()
                     )
                 )
-            )
-            .prompt(Property.ofValue("What is Kestra and what industries does it serve?"))
-            .configuration(ChatConfiguration.builder().temperature(Property.ofValue(0.1)).seed(Property.ofValue(123456789)).build())
-            .build();
+                .build();
 
-        var output = agent.run(runContext);
-        assertThat(output.getTextOutput()).isNotNull();
+            businessIngest.run(runContext);
+
+            // Query using multiple embedding stores + multiple web searches
+            var agent = AIAgent.builder()
+                .provider(
+                    GoogleGemini.builder()
+                        .type(GoogleGemini.class.getName())
+                        .modelName(Property.ofExpression("{{ modelName }}"))
+                        .apiKey(Property.ofExpression("{{ googleApiKey }}"))
+                        .build()
+                )
+                .contentRetrievers(
+                    Property.ofValue(
+                        List.of(
+                            // Embedding Store 1
+                            EmbeddingStoreRetriever.builder()
+                                .embeddings(
+                                    io.kestra.plugin.ai.embeddings.KestraKVStore.builder()
+                                        .kvName(Property.ofValue("technical-docs"))
+                                        .build()
+                                )
+                                .embeddingProvider(
+                                    GoogleGemini.builder()
+                                        .type(GoogleGemini.class.getName())
+                                        .modelName(Property.ofValue("gemini-embedding-001"))
+                                        .apiKey(Property.ofExpression("{{ googleApiKey }}"))
+                                        .build()
+                                )
+                                .build(),
+                            // Embedding Store 2
+                            EmbeddingStoreRetriever.builder()
+                                .embeddings(
+                                    io.kestra.plugin.ai.embeddings.KestraKVStore.builder()
+                                        .kvName(Property.ofValue("business-docs"))
+                                        .build()
+                                )
+                                .embeddingProvider(
+                                    GoogleGemini.builder()
+                                        .type(GoogleGemini.class.getName())
+                                        .modelName(Property.ofValue("gemini-embedding-001"))
+                                        .apiKey(Property.ofExpression("{{ googleApiKey }}"))
+                                        .build()
+                                )
+                                .build(),
+                            // Web Search 1: Tavily
+                            TavilyWebSearch.builder()
+                                .apiKey(Property.ofExpression("{{ tavilyApiKey }}"))
+                                .build(),
+                            // Web Search 2: Google Custom Search
+                            GoogleCustomWebSearch.builder()
+                                .csi(Property.ofExpression("{{ csi }}"))
+                                .apiKey(Property.ofExpression("{{ googleApiKey }}"))
+                                .build()
+                        )
+                    )
+                )
+                .prompt(Property.ofValue("What is Kestra and what industries does it serve?"))
+                .configuration(ChatConfiguration.builder().temperature(Property.ofValue(0.1)).seed(Property.ofValue(123456789)).build())
+                .build();
+
+            var output = agent.run(runContext);
+            assertThat(output.getTextOutput()).isNotNull();
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     /**
@@ -689,92 +708,96 @@ class AIAgentTest {
             )
             .build();
 
-        businessIngest.run(runContext);
+        try {
+            businessIngest.run(runContext);
 
-        var agent = AIAgent.builder()
-            .provider(
-                GoogleGemini.builder()
-                    .type(GoogleGemini.class.getName())
-                    .modelName(Property.ofExpression("{{ modelName }}"))
-                    .apiKey(Property.ofExpression("{{ googleApiKey }}"))
-                    .build()
-            )
-            .contentRetrievers(
-                Property.ofValue(
-                    List.of(
+            var agent = AIAgent.builder()
+                .provider(
+                    GoogleGemini.builder()
+                        .type(GoogleGemini.class.getName())
+                        .modelName(Property.ofExpression("{{ modelName }}"))
+                        .apiKey(Property.ofExpression("{{ googleApiKey }}"))
+                        .build()
+                )
+                .contentRetrievers(
+                    Property.ofValue(
+                        List.of(
 
-                        /* ---------- Pinecone Retriever ---------- */
-                        EmbeddingStoreRetriever.builder()
-                            .embeddings(
-                                io.kestra.plugin.ai.embeddings.Pinecone.builder()
-                                    .apiKey(Property.ofExpression("{{ pineconeApiKey }}"))
-                                    .index(Property.ofValue("embeddings"))
-                                    .cloud(Property.ofValue("aws"))
-                                    .region(Property.ofValue("us-east-1"))
-                                    .namespace(Property.ofValue("test")) // optional
-                                    .build()
-                            )
-                            .embeddingProvider(
-                                GoogleGemini.builder()
-                                    .type(GoogleGemini.class.getName())
-                                    .modelName(Property.ofValue("gemini-embedding-001"))
-                                    .apiKey(Property.ofExpression("{{ googleApiKey }}"))
-                                    .build()
-                            )
-                            .build(),
+                            /* ---------- Pinecone Retriever ---------- */
+                            EmbeddingStoreRetriever.builder()
+                                .embeddings(
+                                    io.kestra.plugin.ai.embeddings.Pinecone.builder()
+                                        .apiKey(Property.ofExpression("{{ pineconeApiKey }}"))
+                                        .index(Property.ofValue("embeddings"))
+                                        .cloud(Property.ofValue("aws"))
+                                        .region(Property.ofValue("us-east-1"))
+                                        .namespace(Property.ofValue("test")) // optional
+                                        .build()
+                                )
+                                .embeddingProvider(
+                                    GoogleGemini.builder()
+                                        .type(GoogleGemini.class.getName())
+                                        .modelName(Property.ofValue("gemini-embedding-001"))
+                                        .apiKey(Property.ofExpression("{{ googleApiKey }}"))
+                                        .build()
+                                )
+                                .build(),
 
-                        /* ---------- KV Store #1 ---------- */
-                        EmbeddingStoreRetriever.builder()
-                            .embeddings(
-                                io.kestra.plugin.ai.embeddings.KestraKVStore.builder()
-                                    .kvName(Property.ofValue("pinecone-sim"))
-                                    .build()
-                            )
-                            .embeddingProvider(
-                                GoogleGemini.builder()
-                                    .type(GoogleGemini.class.getName())
-                                    .modelName(Property.ofValue("gemini-embedding-001"))
-                                    .apiKey(Property.ofExpression("{{ googleApiKey }}"))
-                                    .build()
-                            )
-                            .build(),
+                            /* ---------- KV Store #1 ---------- */
+                            EmbeddingStoreRetriever.builder()
+                                .embeddings(
+                                    io.kestra.plugin.ai.embeddings.KestraKVStore.builder()
+                                        .kvName(Property.ofValue("pinecone-sim"))
+                                        .build()
+                                )
+                                .embeddingProvider(
+                                    GoogleGemini.builder()
+                                        .type(GoogleGemini.class.getName())
+                                        .modelName(Property.ofValue("gemini-embedding-001"))
+                                        .apiKey(Property.ofExpression("{{ googleApiKey }}"))
+                                        .build()
+                                )
+                                .build(),
 
-                        /* ---------- KV Store #2 ---------- */
-                        EmbeddingStoreRetriever.builder()
-                            .embeddings(
-                                io.kestra.plugin.ai.embeddings.KestraKVStore.builder()
-                                    .kvName(Property.ofValue("qdrant-sim"))
-                                    .build()
-                            )
-                            .embeddingProvider(
-                                GoogleGemini.builder()
-                                    .type(GoogleGemini.class.getName())
-                                    .modelName(Property.ofValue("gemini-embedding-001"))
-                                    .apiKey(Property.ofExpression("{{ googleApiKey }}"))
-                                    .build()
-                            )
-                            .build(),
+                            /* ---------- KV Store #2 ---------- */
+                            EmbeddingStoreRetriever.builder()
+                                .embeddings(
+                                    io.kestra.plugin.ai.embeddings.KestraKVStore.builder()
+                                        .kvName(Property.ofValue("qdrant-sim"))
+                                        .build()
+                                )
+                                .embeddingProvider(
+                                    GoogleGemini.builder()
+                                        .type(GoogleGemini.class.getName())
+                                        .modelName(Property.ofValue("gemini-embedding-001"))
+                                        .apiKey(Property.ofExpression("{{ googleApiKey }}"))
+                                        .build()
+                                )
+                                .build(),
 
-                        /* ---------- Tavily Web Search ---------- */
-                        TavilyWebSearch.builder()
-                            .apiKey(Property.ofExpression("{{ tavilyApiKey }}"))
-                            .build()
+                            /* ---------- Tavily Web Search ---------- */
+                            TavilyWebSearch.builder()
+                                .apiKey(Property.ofExpression("{{ tavilyApiKey }}"))
+                                .build()
+                        )
                     )
                 )
-            )
-            .prompt(Property.ofValue("What programming languages does Kestra support and which companies use it?"))
-            .configuration(
-                ChatConfiguration.builder()
-                    .temperature(Property.ofValue(0.1))
-                    .seed(Property.ofValue(123456789))
-                    .build()
-            )
-            .build();
+                .prompt(Property.ofValue("What programming languages does Kestra support and which companies use it?"))
+                .configuration(
+                    ChatConfiguration.builder()
+                        .temperature(Property.ofValue(0.1))
+                        .seed(Property.ofValue(123456789))
+                        .build()
+                )
+                .build();
 
-        var output = agent.run(runContext);
+            var output = agent.run(runContext);
 
-        assertThat(output.getTextOutput()).isNotNull();
-        assertThat(output.getTextOutput()).contains("Kestra");
+            assertThat(output.getTextOutput()).isNotNull();
+            assertThat(output.getTextOutput()).contains("Kestra");
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1055,10 +1078,14 @@ class AIAgentTest {
             )
             .build();
 
-        var output = agent.run(runContext);
-        assertThat(output.getTextOutput()).isNotNull();
-        assertThat(output.getToolExecutions()).isNotEmpty();
-        assertThat(output.getToolExecutions()).extracting("requestName").contains("kestra_task_log");
+        try {
+            var output = agent.run(runContext);
+            assertThat(output.getTextOutput()).isNotNull();
+            assertThat(output.getToolExecutions()).isNotEmpty();
+            assertThat(output.getToolExecutions()).extracting("requestName").contains("kestra_task_log");
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     /**
@@ -1106,10 +1133,14 @@ class AIAgentTest {
             )
             .build();
 
-        // The key check is that no exception is thrown: returnThinking=true and
-        // sendThinking=true must not break a model that produces no thought_signatures.
-        var output = agent.run(runContext);
-        assertThat(output.getTextOutput()).isNotNull();
+        try {
+            // The key check is that no exception is thrown: returnThinking=true and
+            // sendThinking=true must not break a model that produces no thought_signatures.
+            var output = agent.run(runContext);
+            assertThat(output.getTextOutput()).isNotNull();
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @EnabledIfEnvironmentVariable(named = "GOOGLE_API_KEY", matches = ".*")
@@ -1154,10 +1185,14 @@ class AIAgentTest {
             .configuration(ChatConfiguration.builder().temperature(Property.ofValue(0.1)).seed(Property.ofValue(123456789)).build())
             .build();
 
-        var output = agent.run(runContext);
-        assertThat(output.getTextOutput()).isNotNull();
-        assertThat(output.getToolExecutions()).isNotEmpty();
-        assertThat(output.getToolExecutions()).extracting("requestName").contains("activate_skill");
+        try {
+            var output = agent.run(runContext);
+            assertThat(output.getTextOutput()).isNotNull();
+            assertThat(output.getToolExecutions()).isNotEmpty();
+            assertThat(output.getToolExecutions()).extracting("requestName").contains("activate_skill");
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
 }

--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import com.github.tomakehurst.wiremock.http.Body;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -42,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.abort;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @KestraTest
 class ChatCompletionTest extends ContainerTest {
     private final String GEMINI_API_KEY = System.getenv("GEMINI_API_KEY");

--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
@@ -231,7 +231,6 @@ class ChatCompletionTest extends ContainerTest {
             ChatCompletion.Output output = task.run(runContext);
             assertThat(output.getTextOutput(), notNullValue());
             assertThat(output.getTextOutput(), containsString("John"));
-            assertThat(output.getRequestDuration(), notNullValue());
             assertThat(output.getThinking(), notNullValue());
         } catch (RateLimitException e) {
             abort("Skipped: Gemini rate limited (429)");

--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
@@ -274,7 +274,6 @@ class ChatCompletionTest extends ContainerTest {
             ChatCompletion.Output output = task.run(runContext);
             assertThat(output.getTextOutput(), notNullValue());
             assertThat(output.getTextOutput(), containsString("John"));
-            assertThat(output.getRequestDuration(), notNullValue());
             assertThat(output.getThinking(), isEmptyOrNullString());
         } catch (RateLimitException e) {
             abort("Skipped: Gemini rate limited (429)");

--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
@@ -666,11 +666,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".*")
@@ -699,11 +702,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".*")
@@ -735,12 +741,15 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
-        assertThat(output.getTokenUsage().getOutputTokenCount(), equalTo(10));
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+            assertThat(output.getTokenUsage().getOutputTokenCount(), equalTo(10));
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -808,12 +817,15 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
-        assertThat(output.getThinking(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+            assertThat(output.getThinking(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".*")
@@ -845,12 +857,15 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
-        assertThat(output.getThinking(), isEmptyOrNullString());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+            assertThat(output.getThinking(), isEmptyOrNullString());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".*")
@@ -919,11 +934,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1029,11 +1047,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1067,11 +1088,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1137,11 +1161,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1173,11 +1200,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1245,11 +1275,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1316,11 +1349,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1388,11 +1424,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1472,11 +1511,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1509,12 +1551,15 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
-        assertThat(output.getTokenUsage().getOutputTokenCount(), equalTo(10));
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+            assertThat(output.getTokenUsage().getOutputTokenCount(), equalTo(10));
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1553,11 +1598,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1597,11 +1645,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1680,9 +1731,12 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1826,10 +1880,13 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -1947,11 +2004,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -2153,11 +2213,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.getTextOutput(), notNullValue());
-        assertThat(output.getTextOutput(), containsString("John"));
-        assertThat(output.getRequestDuration(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
+            assertThat(output.getTextOutput(), containsString("John"));
+            assertThat(output.getRequestDuration(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -2204,12 +2267,16 @@ class ChatCompletionTest extends ContainerTest {
             .tools(List.of(testTool))
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-        assertThat(output.getTextOutput(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
 
-        task.kill();
+            task.kill();
 
-        assertThat(toolKillCalled[0], equalTo(true));
+            assertThat(toolKillCalled[0], equalTo(true));
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -2269,13 +2336,17 @@ class ChatCompletionTest extends ContainerTest {
             .tools(List.of(testTool1, testTool2))
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-        assertThat(output.getTextOutput(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
 
-        task.kill();
+            task.kill();
 
-        assertThat(tool1KillCalled[0], equalTo(true));
-        assertThat(tool2KillCalled[0], equalTo(true));
+            assertThat(tool1KillCalled[0], equalTo(true));
+            assertThat(tool2KillCalled[0], equalTo(true));
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -2336,13 +2407,17 @@ class ChatCompletionTest extends ContainerTest {
             .tools(List.of(failingTool, normalTool))
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-        assertThat(output.getTextOutput(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.getTextOutput(), notNullValue());
 
-        task.kill();
+            task.kill();
 
-        assertThat(tool1KillCalled[0], equalTo(true));
-        assertThat(tool2KillCalled[0], equalTo(true));
+            assertThat(tool1KillCalled[0], equalTo(true));
+            assertThat(tool2KillCalled[0], equalTo(true));
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -2387,10 +2462,13 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.isGuardrailViolated(), is(false));
-        assertThat(output.getTextOutput(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.isGuardrailViolated(), is(false));
+            assertThat(output.getTextOutput(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -2485,10 +2563,13 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.isGuardrailViolated(), is(false));
-        assertThat(output.getTextOutput(), notNullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.isGuardrailViolated(), is(false));
+            assertThat(output.getTextOutput(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -2534,11 +2615,14 @@ class ChatCompletionTest extends ContainerTest {
             )
             .build();
 
-        ChatCompletion.Output output = task.run(runContext);
-
-        assertThat(output.isGuardrailViolated(), is(true));
-        assertThat(output.getGuardrailViolationMessage(), containsString("Response contains confidential information"));
-        assertThat(output.getTextOutput(), nullValue());
+        try {
+            ChatCompletion.Output output = task.run(runContext);
+            assertThat(output.isGuardrailViolated(), is(true));
+            assertThat(output.getGuardrailViolationMessage(), containsString("Response contains confidential information"));
+            assertThat(output.getTextOutput(), nullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
 }

--- a/src/test/java/io/kestra/plugin/ai/completion/ClassificationTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ClassificationTest.java
@@ -108,11 +108,14 @@ class ClassificationTest extends ContainerTest {
             )
             .build();
 
-        // WHEN
-        Classification.Output runOutput = task.run(runContext);
+        // WHEN / THEN
+        try {
+            Classification.Output runOutput = task.run(runContext);
 
-        // THEN
-        assertThat(runOutput.getClassification(), notNullValue());
+            assertThat(runOutput.getClassification(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -267,10 +270,14 @@ class ClassificationTest extends ContainerTest {
             )
             .build();
 
-        Classification.Output output = task.run(runContext);
+        try {
+            Classification.Output output = task.run(runContext);
 
-        assertThat(output.isGuardrailViolated(), is(false));
-        assertThat(output.getClassification(), notNullValue());
+            assertThat(output.isGuardrailViolated(), is(false));
+            assertThat(output.getClassification(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -310,11 +317,15 @@ class ClassificationTest extends ContainerTest {
             )
             .build();
 
-        Classification.Output output = task.run(runContext);
+        try {
+            Classification.Output output = task.run(runContext);
 
-        assertThat(output.isGuardrailViolated(), is(true));
-        assertThat(output.getGuardrailViolationMessage(), containsString("Response contains confidential information"));
-        assertThat(output.getClassification(), nullValue());
+            assertThat(output.isGuardrailViolated(), is(true));
+            assertThat(output.getGuardrailViolationMessage(), containsString("Response contains confidential information"));
+            assertThat(output.getClassification(), nullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/ai/completion/JSONStructuredExtractionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/JSONStructuredExtractionTest.java
@@ -204,10 +204,14 @@ class JSONStructuredExtractionTest extends ContainerTest {
             )
             .build();
 
-        JSONStructuredExtraction.Output output = task.run(runContext);
+        try {
+            JSONStructuredExtraction.Output output = task.run(runContext);
 
-        assertThat(output.isGuardrailViolated(), is(false));
-        assertThat(output.getExtractedJson(), notNullValue());
+            assertThat(output.isGuardrailViolated(), is(false));
+            assertThat(output.getExtractedJson(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -292,10 +296,14 @@ class JSONStructuredExtractionTest extends ContainerTest {
             )
             .build();
 
-        JSONStructuredExtraction.Output output = task.run(runContext);
+        try {
+            JSONStructuredExtraction.Output output = task.run(runContext);
 
-        assertThat(output.isGuardrailViolated(), is(false));
-        assertThat(output.getExtractedJson(), notNullValue());
+            assertThat(output.isGuardrailViolated(), is(false));
+            assertThat(output.getExtractedJson(), notNullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test
@@ -336,11 +344,15 @@ class JSONStructuredExtractionTest extends ContainerTest {
             )
             .build();
 
-        JSONStructuredExtraction.Output output = task.run(runContext);
+        try {
+            JSONStructuredExtraction.Output output = task.run(runContext);
 
-        assertThat(output.isGuardrailViolated(), is(true));
-        assertThat(output.getGuardrailViolationMessage(), containsString("Response contains confidential information"));
-        assertThat(output.getExtractedJson(), nullValue());
+            assertThat(output.isGuardrailViolated(), is(true));
+            assertThat(output.getGuardrailViolationMessage(), containsString("Response contains confidential information"));
+            assertThat(output.getExtractedJson(), nullValue());
+        } catch (RateLimitException e) {
+            abort("Skipped: rate limited or quota exceeded");
+        }
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/ai/memory/KestraKVStoreTest.java
+++ b/src/test/java/io/kestra/plugin/ai/memory/KestraKVStoreTest.java
@@ -29,21 +29,30 @@ class KestraKVStoreTest extends ContainerTest {
     @Test
     void testMemory() throws Exception {
         RunContext runContext = runContextFactory.of(
-            "namespace", Map.of(
+            "io.kestra.plugin.ai.memory", Map.of(
                 "modelName", "tinydolphin",
+                "embeddingModelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint,
                 "labels", Map.of("system", Map.of("correlationId", IdUtils.create()))
             )
         );
 
-        var ollamaProvider = Ollama.builder()
-            .type(Ollama.class.getName())
-            .modelName(Property.ofExpression("{{ modelName }}"))
-            .endpoint(Property.ofExpression("{{ endpoint }}"))
-            .build();
-
         var rag = ChatCompletion.builder()
-            .chatProvider(ollamaProvider)
+            .chatProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddings(io.kestra.plugin.ai.embeddings.KestraKVStore.builder().build())
             .memory(KestraKVStore.builder().build())
             .prompt(Property.ofValue("Hello, my name is John"))
             // Use a low temperature and a fixed seed so the completion would be more deterministic
@@ -55,7 +64,21 @@ class KestraKVStoreTest extends ContainerTest {
 
         // call it a second time, it should use the memory
         rag = ChatCompletion.builder()
-            .chatProvider(ollamaProvider)
+            .chatProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddings(io.kestra.plugin.ai.embeddings.KestraKVStore.builder().build())
             .memory(KestraKVStore.builder().build())
             .prompt(Property.ofValue("What's my name?"))
             // Use a low temperature and a fixed seed so the completion would be more deterministic

--- a/src/test/java/io/kestra/plugin/ai/memory/KestraKVStoreTest.java
+++ b/src/test/java/io/kestra/plugin/ai/memory/KestraKVStoreTest.java
@@ -31,28 +31,19 @@ class KestraKVStoreTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
                 "modelName", "tinydolphin",
-                "embeddingModelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint,
                 "labels", Map.of("system", Map.of("correlationId", IdUtils.create()))
             )
         );
 
+        var ollamaProvider = Ollama.builder()
+            .type(Ollama.class.getName())
+            .modelName(Property.ofExpression("{{ modelName }}"))
+            .endpoint(Property.ofExpression("{{ endpoint }}"))
+            .build();
+
         var rag = ChatCompletion.builder()
-            .chatProvider(
-                Ollama.builder()
-                    .type(Ollama.class.getName())
-                    .modelName(Property.ofExpression("{{ modelName }}"))
-                    .endpoint(Property.ofExpression("{{ endpoint }}"))
-                    .build()
-            )
-            .embeddingProvider(
-                Ollama.builder()
-                    .type(Ollama.class.getName())
-                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
-                    .endpoint(Property.ofExpression("{{ endpoint }}"))
-                    .build()
-            )
-            .embeddings(io.kestra.plugin.ai.embeddings.KestraKVStore.builder().build())
+            .chatProvider(ollamaProvider)
             .memory(KestraKVStore.builder().build())
             .prompt(Property.ofValue("Hello, my name is John"))
             // Use a low temperature and a fixed seed so the completion would be more deterministic
@@ -64,21 +55,7 @@ class KestraKVStoreTest extends ContainerTest {
 
         // call it a second time, it should use the memory
         rag = ChatCompletion.builder()
-            .chatProvider(
-                Ollama.builder()
-                    .type(Ollama.class.getName())
-                    .modelName(Property.ofExpression("{{ modelName }}"))
-                    .endpoint(Property.ofExpression("{{ endpoint }}"))
-                    .build()
-            )
-            .embeddingProvider(
-                Ollama.builder()
-                    .type(Ollama.class.getName())
-                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
-                    .endpoint(Property.ofExpression("{{ endpoint }}"))
-                    .build()
-            )
-            .embeddings(io.kestra.plugin.ai.embeddings.KestraKVStore.builder().build())
+            .chatProvider(ollamaProvider)
             .memory(KestraKVStore.builder().build())
             .prompt(Property.ofValue("What's my name?"))
             // Use a low temperature and a fixed seed so the completion would be more deterministic

--- a/src/test/java/io/kestra/plugin/ai/memory/KestraKVStoreTest.java
+++ b/src/test/java/io/kestra/plugin/ai/memory/KestraKVStoreTest.java
@@ -3,6 +3,8 @@ package io.kestra.plugin.ai.memory;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import io.kestra.core.context.TestRunContextFactory;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -18,6 +20,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @KestraTest
 class KestraKVStoreTest extends ContainerTest {
     @Inject

--- a/src/test/java/io/kestra/plugin/ai/rag/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/rag/ChatCompletionTest.java
@@ -408,6 +408,8 @@ class ChatCompletionTest extends ContainerTest {
             assertThat(ragOutput.getTextOutput()).containsAnyOf("Paris", "Berlin");
 
             postgres.stop();
+        } catch (RateLimitException e) {
+            abort("Skipped: OpenAI rate limited or quota exceeded");
         }
     }
 }

--- a/src/test/java/io/kestra/plugin/ai/rag/IngestDocumentTest.java
+++ b/src/test/java/io/kestra/plugin/ai/rag/IngestDocumentTest.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -30,6 +32,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @KestraTest
 class IngestDocumentTest extends ContainerTest {
 

--- a/src/test/java/io/kestra/plugin/ai/rag/SearchTest.java
+++ b/src/test/java/io/kestra/plugin/ai/rag/SearchTest.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import io.kestra.core.context.TestRunContextFactory;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -17,6 +19,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @KestraTest
 class SearchTest extends ContainerTest {
 

--- a/src/test/java/io/kestra/plugin/ai/tool/A2AClientTest.java
+++ b/src/test/java/io/kestra/plugin/ai/tool/A2AClientTest.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
@@ -22,6 +24,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @KestraTest(startRunner = true)
 class A2AClientTest {
     @Inject

--- a/src/test/java/io/kestra/plugin/ai/tool/AIAgentTest.java
+++ b/src/test/java/io/kestra/plugin/ai/tool/AIAgentTest.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
@@ -20,6 +22,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @KestraTest(startRunner = true)
 class AIAgentTest {
     @Inject

--- a/src/test/java/io/kestra/plugin/ai/tool/DockerMcpClientTest.java
+++ b/src/test/java/io/kestra/plugin/ai/tool/DockerMcpClientTest.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
@@ -20,6 +22,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @KestraTest
 class DockerMcpClientTest {
     @Inject

--- a/src/test/java/io/kestra/plugin/ai/tool/KestraFlowTest.java
+++ b/src/test/java/io/kestra/plugin/ai/tool/KestraFlowTest.java
@@ -11,6 +11,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import com.sun.net.httpserver.HttpServer;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
@@ -28,6 +30,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @KestraTest(startRunner = true)
 class KestraFlowTest {
     @Inject

--- a/src/test/java/io/kestra/plugin/ai/tool/KestraTaskTest.java
+++ b/src/test/java/io/kestra/plugin/ai/tool/KestraTaskTest.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import io.kestra.plugin.core.log.Fetch;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.annotations.Plugin;
@@ -41,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assumptions.abort;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @KestraTest
 class KestraTaskTest extends ContainerTest {
     private final String GEMINI_API_KEY = System.getenv("GEMINI_API_KEY");

--- a/src/test/java/io/kestra/plugin/ai/tool/SkillTest.java
+++ b/src/test/java/io/kestra/plugin/ai/tool/SkillTest.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
@@ -24,6 +26,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @KestraTest(startRunner = true)
 class SkillTest {
     @Inject

--- a/src/test/java/io/kestra/plugin/ai/tool/SseMcpClientTest.java
+++ b/src/test/java/io/kestra/plugin/ai/tool/SseMcpClientTest.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -25,6 +27,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @KestraTest
 class SseMcpClientTest {
     @Inject

--- a/src/test/java/io/kestra/plugin/ai/tool/StdioMcpClientTest.java
+++ b/src/test/java/io/kestra/plugin/ai/tool/StdioMcpClientTest.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
@@ -20,6 +22,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @KestraTest
 class StdioMcpClientTest {
     @Inject

--- a/src/test/java/io/kestra/plugin/ai/tool/StreamableHttpMcpClientTest.java
+++ b/src/test/java/io/kestra/plugin/ai/tool/StreamableHttpMcpClientTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -26,6 +28,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Execution(ExecutionMode.SAME_THREAD)
 @Disabled("The streamable HTTP server is not yet available inside the Docker container")
 @KestraTest
 class StreamableHttpMcpClientTest {

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=4

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,5 +1,0 @@
-junit.jupiter.execution.parallel.enabled=true
-junit.jupiter.execution.parallel.mode.default=same_thread
-junit.jupiter.execution.parallel.mode.classes.default=concurrent
-junit.jupiter.execution.parallel.config.strategy=fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism=4


### PR DESCRIPTION
## Summary
- `rag_givenSqlDatabaseRetriever_withPostgres` was failing CI with `RateLimitException` (OpenAI `insufficient_quota`)
- Adds `catch (RateLimitException e) { abort(...) }` — same pattern already used for Gemini/VertexAI tests
- Test now skips instead of fails when OpenAI account has no quota

Fixes https://github.com/kestra-io/plugin-ai/actions/runs/28076965802/job/83123121883