### PR TITLE
fix(test): remove global TimingChatModelListener.clear() to prevent race condition

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/agent/AIAgent.java
+++ b/src/main/java/io/kestra/plugin/ai/agent/AIAgent.java
@@ -26,7 +26,6 @@ import io.kestra.plugin.ai.AIUtils;
 import io.kestra.plugin.ai.domain.*;
 import io.kestra.plugin.ai.guardrail.GuardrailsEvaluator;
 import io.kestra.plugin.ai.observability.LangfuseObservabilityListeners;
-import io.kestra.plugin.ai.provider.TimingChatModelListener;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.exception.ToolArgumentsException;
@@ -825,8 +824,6 @@ public class AIAgent extends Task implements RunnableTask<AIOutput>, OutputFiles
             if (memory != null) {
                 memory.close(runContext);
             }
-
-            TimingChatModelListener.clear();
         }
     }
 

--- a/src/main/java/io/kestra/plugin/ai/completion/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/ChatCompletion.java
@@ -33,7 +33,6 @@ import io.kestra.plugin.ai.domain.TokenUsage;
 import io.kestra.plugin.ai.domain.ToolProvider;
 import io.kestra.plugin.ai.guardrail.GuardrailsEvaluator;
 import io.kestra.plugin.ai.observability.LangfuseObservabilityListeners;
-import io.kestra.plugin.ai.provider.TimingChatModelListener;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
@@ -381,8 +380,6 @@ public class ChatCompletion extends Task implements RunnableTask<ChatCompletion.
         } finally {
             observabilityListeners.close();
             toolProviders.forEach(tool -> tool.close(runContext));
-
-            TimingChatModelListener.clear();
         }
     }
 

--- a/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
@@ -19,7 +19,6 @@ import io.kestra.core.utils.ListUtils;
 import io.kestra.plugin.ai.AIUtils;
 import io.kestra.plugin.ai.domain.*;
 import io.kestra.plugin.ai.guardrail.GuardrailsEvaluator;
-import io.kestra.plugin.ai.provider.TimingChatModelListener;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.exception.ToolArgumentsException;
@@ -413,8 +412,6 @@ public class ChatCompletion extends Task implements RunnableTask<ChatCompletion.
             if (memory != null) {
                 memory.close(runContext);
             }
-
-            TimingChatModelListener.clear();
         }
     }
 


### PR DESCRIPTION
## Summary

- `TimingChatModelListener.clear()` was called in the `finally` block of `ChatCompletion`, `rag.ChatCompletion`, and `AIAgent`
- Because the timer maps are **static**, this global clear raced with other parallel tests: one task's `finally` wiped another task's pending `onResponse` timer before `extractTiming` could retrieve it, causing `requestDuration` to be null
- This manifested as a flaky `AssertionError: Expected not null but was null` on `requestDuration` in `ChatCompletionTest.testGeminiChatCompletion_withClientAndCaPem_shouldUseMtls`
- Fix: remove the three `clear()` calls — `getTimer()` already uses `remove()` on both maps so entries self-clean on the normal path

## Test plan

- [ ] Existing `testGeminiChatCompletion_withClientAndCaPem_shouldUseMtls` should now pass consistently under parallel test execution
- [ ] All other tests unaffected (no functional change)