### PR TITLE
fix: handle null chatResponse id in TimingChatModelListener

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/provider/TimingChatModelListener.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/TimingChatModelListener.java
@@ -47,6 +47,11 @@ public class TimingChatModelListener implements ChatModelListener {
             return;
         }
         stopWatch.stop();
-        TIMER_ID_BY_RESPONSE_ID.put(responseContext.chatResponse().id(), timerId);
+        String responseId = responseContext.chatResponse().id();
+        if (responseId != null) {
+            TIMER_ID_BY_RESPONSE_ID.put(responseId, timerId);
+        } else {
+            TIMERS.remove(timerId);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `ConcurrentHashMap` rejects null keys; providers like Ollama return a null `id()` from `chatResponse()`, causing NPE at `TimingChatModelListener.java:50`
- Added null-check before `put()` and removes the orphaned timer from `TIMERS` to prevent a memory leak

## Root cause

CI failure: `RedisTest.testMemory()` uses Ollama, whose chat response has no `id` field → `chatResponse().id()` returns `null` → `ConcurrentHashMap.put(null, timerId)` throws `NullPointerException`.