### PR TITLE
fix(test): tolerate Mistral 401 body change in ChatCompletion test

### DIFF
--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
@@ -984,8 +984,14 @@ class ChatCompletionTest extends ContainerTest {
             ChatCompletion.Output output = task.run(runContext);
         }, "status code: 401");
 
-        // Verify error message contains 404 details
-        assertThat(exception.getMessage(), containsString("Unauthorized"));
+        // Mistral returns a 401 whose body may be either a plain "Unauthorized"
+        // message or a JSON payload like {"detail":"Invalid API Key"}.
+        assertThat(
+            exception.getMessage(), anyOf(
+                containsString("Unauthorized"),
+                containsString("Invalid API Key")
+            )
+        );
     }
 
     @Test


### PR DESCRIPTION
## What

Fixes the failing `ChatCompletionTest.testChatCompletionMistralAI_givenInvalidApiKey_shouldThrow4xxUnAuthorizedException()` test.

## Why

Mistral still returns a 401 for an invalid API key, but changed the response body from a message containing `Unauthorized` to the JSON payload `{"detail":"Invalid API Key"}`. The test hard-asserted `containsString("Unauthorized")` and started failing on CI.

Failing run: https://github.com/kestra-io/plugin-ai/actions/runs/31086458777/job/92566944090

```
Expected: a string containing "Unauthorized"
     but: was "{"detail":"Invalid API Key"}"
```

## How

The assertion now accepts either body via `anyOf(containsString("Unauthorized"), containsString("Invalid API Key"))`, matching the same pattern already used for other providers in this file (e.g. the OpenRouter test). The test still verifies a 401 is thrown, it just no longer depends on Mistral's exact error wording.

Note: this test hits the live Mistral endpoint, so it is not executed locally without network access. The change compiles cleanly.