### PR TITLE
chore(deps): bump langchain4j, axios, undici

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 
 def isBuildSnapshot = version.toString().endsWith("-SNAPSHOT")
 
-def langchain4jVersion = "1.16.3"
+def langchain4jVersion = "1.19.0"
 def langchain4jBetaVersion = "1.13.0-beta23"
 
 repositories {

--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
@@ -800,7 +800,7 @@ class ChatCompletionTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             Map.of(
                 "apiKey", ANTHROPIC_API_KEY,
-                "modelName", AnthropicChatModelName.CLAUDE_SONNET_4_20250514,
+                "modelName", AnthropicChatModelName.CLAUDE_SONNET_4_5_20250929,
                 "messages", List.of(
                     ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
                 )
@@ -841,7 +841,7 @@ class ChatCompletionTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             Map.of(
                 "apiKey", ANTHROPIC_API_KEY,
-                "modelName", AnthropicChatModelName.CLAUDE_SONNET_4_20250514,
+                "modelName", AnthropicChatModelName.CLAUDE_SONNET_4_5_20250929,
                 "messages", List.of(
                     ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
                 )
@@ -881,7 +881,7 @@ class ChatCompletionTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             Map.of(
                 "apiKey", ANTHROPIC_API_KEY,
-                "modelName", AnthropicChatModelName.CLAUDE_SONNET_4_20250514,
+                "modelName", AnthropicChatModelName.CLAUDE_SONNET_4_5_20250929,
                 "messages", List.of(
                     ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
                 )

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@kestra-io/artifact-sdk": "0.1.2",
         "@kestra-io/design-system": "0.3.0",
-        "@kestra-io/kestra-sdk": "2.0.0-kdevelop.17830727.7ce38d9a.a4050f62",
+        "@kestra-io/kestra-sdk": "2.0.0-kdevelop.17845587.03d97066.b669944a",
         "vue": "3.5.38"
       },
       "devDependencies": {
@@ -1161,12 +1161,11 @@
       }
     },
     "node_modules/@kestra-io/kestra-sdk": {
-      "version": "2.0.0-kdevelop.17830727.7ce38d9a.a4050f62",
-      "resolved": "https://registry.npmjs.org/@kestra-io/kestra-sdk/-/kestra-sdk-2.0.0-kdevelop.17830727.7ce38d9a.a4050f62.tgz",
-      "integrity": "sha512-kMIG1cfvDOaTBRhgOMW9rcNbB2wlVAIVbFK3aSnROGrP/mUfB9NbTmBhz2R8CFrTLaV/f19zFLp0od6KQ+Lt4w==",
+      "version": "2.0.0-kdevelop.17845587.03d97066.b669944a",
+      "resolved": "https://registry.npmjs.org/@kestra-io/kestra-sdk/-/kestra-sdk-2.0.0-kdevelop.17845587.03d97066.b669944a.tgz",
+      "integrity": "sha512-Lx3VfaF1AZBkSYJdHcqEV6CcmSDcEb971ocZdIEQsuXsoYUpzW6+TPx8KAsg3YJFq0f+zNTFRgHSxIrc1KoJew==",
       "license": "Unlicense",
       "dependencies": {
-        "axios": "1.16.1",
         "nprogress": "0.2.0"
       }
     },
@@ -4375,18 +4374,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/alien-signals": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
@@ -4522,24 +4509,6 @@
       "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==",
       "license": "MIT"
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "node_modules/babel-walk": {
       "version": "3.0.0-canary-5",
       "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
@@ -4640,6 +4609,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4767,18 +4737,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/comma-separated-tokens": {
@@ -5504,15 +5462,6 @@
         "robust-predicates": "^3.0.2"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5572,6 +5521,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5614,6 +5564,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5623,6 +5574,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5639,24 +5591,10 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5870,42 +5808,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
@@ -5941,6 +5843,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5965,6 +5868,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -6008,6 +5912,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6026,6 +5931,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6038,6 +5944,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6154,19 +6061,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/humanize-duration": {
@@ -7005,6 +6899,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7899,27 +7794,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -8510,15 +8384,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/pug": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1197,46 +1197,46 @@
       }
     },
     "node_modules/@module-federation/error-codes": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.5.1.tgz",
-      "integrity": "sha512-3KIR8XbEW0Y+Fn8IAnxzDWMvXQWiS40Z1TE/Fft9aTeXP9dDAM7AiVhjTh5yF2csAwHSt/1LJVZbiCmS13mE8A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.6.0.tgz",
+      "integrity": "sha512-J9opjWJJZ1JI/9EvNZF8Ps1VMHS9EsH/i0UjCkQQxFVYZxSDBX1CFunvc7awac4cY//LqJUfqBbfoQPhCfKKKw==",
       "license": "MIT"
     },
     "node_modules/@module-federation/managers": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.5.1.tgz",
-      "integrity": "sha512-AWbkH/U76FJDbdwBOodQ1An40WOdrDGAgqUMc8RD62+Ec/ocPfda0NhFcJbPxlUIvSFPTvBv6DwTnygmNC7GPA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.6.0.tgz",
+      "integrity": "sha512-7Y4Ri6Lh10dCHoEJvNGFmK2Gg1JKy7oJ1TEZhuU3n3mgIpZ519fDNRvU4+tiO9C49p1xyK+mQ8ewxth83waKUA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.5.1",
+        "@module-federation/sdk": "2.6.0",
         "find-pkg": "2.0.0"
       }
     },
     "node_modules/@module-federation/runtime": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.5.1.tgz",
-      "integrity": "sha512-Tf33FIpnQMn8FjIUAQMtSTYQgGibfh5vEvJihFO3q/hG9LiWwLMErZvOz/+wcPsE81gzHjYPxQgMKGSP3BuG8g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.6.0.tgz",
+      "integrity": "sha512-Y8KgL70RDxD8cCtGWGlGkt+TSDleIjdGmS27gnllibQAIgG/vHhPD11r8kd92x44k4dqtMIntzreOphGICl92g==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.5.1",
-        "@module-federation/runtime-core": "2.5.1",
-        "@module-federation/sdk": "2.5.1"
+        "@module-federation/error-codes": "2.6.0",
+        "@module-federation/runtime-core": "2.6.0",
+        "@module-federation/sdk": "2.6.0"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.5.1.tgz",
-      "integrity": "sha512-UMuMsWHXeMrm8Isl8YD6/s1jmTVau3SQhp9RO4Ln+eD2lrjM4hQSwOX2xPtfT1C1I4/E6hgyZQV1K1Q/3Zpr0Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.6.0.tgz",
+      "integrity": "sha512-9sL7Yj3H3COZI9JpK/J4hmJUBkIJdmowkj6phHuFiy5Hm5bHiE5U+9WBbR9KqTdyNhAVSL9FeprBW5/Io6i59A==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.5.1",
-        "@module-federation/sdk": "2.5.1"
+        "@module-federation/error-codes": "2.6.0",
+        "@module-federation/sdk": "2.6.0"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.1.tgz",
-      "integrity": "sha512-FDhCx81ZCxX1oT/fyt/bW+gpPt287GR156E/Thv1yhb9XyNHGNkqe8zqJOipOMfb07E22OMzSzOulCBvAOgn3g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.6.0.tgz",
+      "integrity": "sha512-Z3HT1uDciMrvz2at3sw6TJbAK9Fl7RmoC/8iqO35HDtQMQJ1qSsMIAjnsiCpAC0D4nAm6PIqgSqPWRO/WYgo0Q==",
       "license": "MIT",
       "peerDependencies": {
         "node-fetch": "^2.7.0 || ^3.3.2"
@@ -1248,9 +1248,9 @@
       }
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.5.1.tgz",
-      "integrity": "sha512-/jD/o2IivDgg6jGUgdb9NZtlJWeoz1uKcblGL2BxYVzzlKT+1YS7Y2idTl1tqp4hNdFnDlPpQv6WLdKiLoOPNw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.6.0.tgz",
+      "integrity": "sha512-rEC1YRC3gTafoOcFm1Htz6cAwHRoWEMQNCm1LXR1HiuayJzUkViVpK/1Pp37UZfytOyQ0qIaP6Ag81PdGvDbmw==",
       "license": "MIT",
       "dependencies": {
         "find-pkg": "2.0.0",
@@ -1275,14 +1275,14 @@
       }
     },
     "node_modules/@module-federation/vite": {
-      "version": "1.16.10",
-      "resolved": "https://registry.npmjs.org/@module-federation/vite/-/vite-1.16.10.tgz",
-      "integrity": "sha512-I6g3qALD98cB7GuuuausT/l96GjgWuCeaikue0rbOleUmVp4P7JRHR4UW8uQXekmiMwWmAjTApsQ+qrMrDmzcw==",
+      "version": "1.16.11",
+      "resolved": "https://registry.npmjs.org/@module-federation/vite/-/vite-1.16.11.tgz",
+      "integrity": "sha512-tmVBSdHDDQvGPYPZgp7Hpi980reReObP1yyai3kxWeQZ8CL6zAFIgz3wb97o20J/lJjxM6DDzs31da3RXtvdxA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.5.1",
-        "@module-federation/runtime": "2.5.1",
-        "@module-federation/sdk": "2.5.1"
+        "@module-federation/dts-plugin": "2.6.0",
+        "@module-federation/runtime": "2.6.0",
+        "@module-federation/sdk": "2.6.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -1292,20 +1292,20 @@
       }
     },
     "node_modules/@module-federation/vite/node_modules/@module-federation/dts-plugin": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.5.1.tgz",
-      "integrity": "sha512-XylIL02As+VXk4DzFb8qYQs1YYoY0MZOpIqhf06LMkZBjPdOE0wJ1GOBvhFP9kM/cfuK7QV//mNdrWlZgvEkRA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.6.0.tgz",
+      "integrity": "sha512-0dMjLhU+2HNPyX5Txu6JqA2CAYxVLRv3c/bpRk58aNVwhDO/jqp66IdFztdMZ1XiHqOW9jB3pkOSuIpcl/yXpQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.5.1",
-        "@module-federation/managers": "2.5.1",
-        "@module-federation/sdk": "2.5.1",
-        "@module-federation/third-party-dts-extractor": "2.5.1",
+        "@module-federation/error-codes": "2.6.0",
+        "@module-federation/managers": "2.6.0",
+        "@module-federation/sdk": "2.6.0",
+        "@module-federation/third-party-dts-extractor": "2.6.0",
         "adm-zip": "0.5.10",
         "ansi-colors": "4.1.3",
         "isomorphic-ws": "5.0.0",
         "node-schedule": "2.1.1",
-        "undici": "7.24.7",
+        "undici": "7.28.0",
         "ws": "8.21.0"
       },
       "peerDependencies": {
@@ -9277,9 +9277,9 @@
       "peer": true
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@kestra-io/artifact-sdk": "0.1.2",
     "@kestra-io/design-system": "0.3.0",
-    "@kestra-io/kestra-sdk": "2.0.0-kdevelop.17830727.7ce38d9a.a4050f62",
+    "@kestra-io/kestra-sdk": "2.0.0-kdevelop.17845587.03d97066.b669944a",
     "vue": "3.5.38"
   },
   "devDependencies": {

--- a/ui/src/AITopologyDetails.stories.ts
+++ b/ui/src/AITopologyDetails.stories.ts
@@ -43,21 +43,21 @@ function mockResolveTemplate(template: string, hasExecution: boolean): string {
 // any global mutable state — the intent travels in the request body.
 const RENDER_FAILURE_FLOW_ID = "ai_pebble_render_failure";
 
-// The generated client invokes `axios(config)`; replace that transport with a stub that
-// renders the request's expressions per the rules above. Scoped to the expressions-render
-// endpoint only: any other SDK call throws loudly rather than silently receiving a fake 200,
-// so this module-level transport swap can't mask a real request in a future test that shares
+// The generated client is fetch-based; replace its `fetch` with a stub that renders the
+// request's expressions per the rules above. Scoped to the expressions-render endpoint only:
+// any other SDK call throws loudly rather than silently receiving a fake 200, so this
+// module-level transport swap can't mask a real request in a future test that shares
 // this worker's client singleton.
 client.setConfig({
-    axios: (async (config: {
-        url?: string;
-        data?: unknown;
-        validateStatus?: (status: number) => boolean;
-    }) => {
-        if (!String(config.url ?? "").includes("expressions/render")) {
-            throw new Error(`Stories mock received an unexpected SDK request: ${config.url}`);
+    // The fetch client builds a `new Request(url)`, which requires an absolute URL in the
+    // test runner (no browser origin to resolve against) — any dummy origin works, the stub
+    // below never performs a real network call.
+    baseUrl: "http://storybook.mock",
+    fetch: (async (request: Request) => {
+        if (!request.url.includes("expressions/render")) {
+            throw new Error(`Stories mock received an unexpected SDK request: ${request.url}`);
         }
-        const body = (typeof config.data === "string" ? JSON.parse(config.data) : config.data) as {
+        const body = (await request.clone().json()) as {
             expressions?: string[];
             executionId?: string;
             flowId?: string;
@@ -70,24 +70,11 @@ client.setConfig({
                 rendered[expression] = mockResolveTemplate(expression, hasExecution);
             }
         }
-        const response = {
-            data: status === 200 ? { rendered } : {},
+        return new Response(JSON.stringify(status === 200 ? { rendered } : {}), {
             status,
             statusText: status === 200 ? "OK" : "Forbidden",
-            headers: {},
-            config,
-        };
-        // Mimic axios: reject when the status is not accepted by the caller's validateStatus,
-        // so useRenderedExpressions' try/catch runs exactly as it does against a real server.
-        const accept = config.validateStatus ?? ((s: number) => s >= 200 && s < 300);
-        if (!accept(status)) {
-            const error = new Error(`Request failed with status code ${status}`) as Error & {
-                response?: unknown;
-            };
-            error.response = response;
-            throw error;
-        }
-        return response;
+            headers: { "Content-Type": "application/json" },
+        });
     }) as never,
 });
 


### PR DESCRIPTION
## Summary
Combines 3 dependabot PRs into one, plus a required fix:
- bump langchain4jVersion from 1.16.3 to 1.19.0 (#392)
- bump axios in /ui (#374)
- bump undici in /ui (#353)
- fix(test): update `AnthropicChatModelName.CLAUDE_SONNET_4_20250514` (removed in langchain4j-anthropic 1.19.0) to `CLAUDE_SONNET_4_5_20250929` — without this, `compileTestJava` fails

Closes #392, closes #374, closes #353

## Test plan
- [x] `./gradlew compileJava compileTestJava` succeeds